### PR TITLE
Add functionality for getting entries from zones with provided status

### DIFF
--- a/WarehouseManagement.Common/Statuses/ZoneEntryStatuses.cs
+++ b/WarehouseManagement.Common/Statuses/ZoneEntryStatuses.cs
@@ -1,9 +1,9 @@
 ﻿namespace WarehouseManagement.Common.Statuses
 {
-    public static class ZoneEntryStatuses
+    public enum ZoneEntryStatuses
     {
-        public const string Waiting = "Waiting";
-        public const string Processing = "Processing";
-        public const string Finished = "Finished";
+        Waiting,
+        Processing,
+        Finished
     }
 }

--- a/WarehouseManagement.Common/Statuses/ZoneEntryStatuses.cs
+++ b/WarehouseManagement.Common/Statuses/ZoneEntryStatuses.cs
@@ -1,0 +1,9 @@
+﻿namespace WarehouseManagement.Common.Statuses
+{
+    public static class ZoneEntryStatuses
+    {
+        public const string Waiting = "Waiting";
+        public const string Processing = "Processing";
+        public const string Finished = "Finished";
+    }
+}

--- a/WarehouseManagement.Core/Contracts/IZoneService.cs
+++ b/WarehouseManagement.Core/Contracts/IZoneService.cs
@@ -14,6 +14,8 @@ namespace WarehouseManagement.Core.Contracts
         Task<string> RestoreAsync(int id);
         Task<bool> ExistsByIdAsync(int id);
         Task<bool> ExistsByNameAsync(string name);
-        Task<IEnumerable<ZoneEntryDto>> GetEntriesAsync(int id, Predicate<Entry> predicate);
+        Task<IEnumerable<ZoneEntryDto>> GetWaitingEntries(int zoneId);
+        Task<IEnumerable<ZoneEntryDto>> GetProccessingEntries(int zoneId);
+        Task<IEnumerable<ZoneEntryDto>> GetFinishedEntries(int zoneId);
     }
 }

--- a/WarehouseManagement.Core/Contracts/IZoneService.cs
+++ b/WarehouseManagement.Core/Contracts/IZoneService.cs
@@ -1,4 +1,5 @@
 ﻿using WarehouseManagement.Core.DTOs.Zone;
+using WarehouseManagement.Infrastructure.Data.Models;
 
 namespace WarehouseManagement.Core.Contracts
 {
@@ -13,5 +14,6 @@ namespace WarehouseManagement.Core.Contracts
         Task<string> RestoreAsync(int id);
         Task<bool> ExistsByIdAsync(int id);
         Task<bool> ExistsByNameAsync(string name);
+        Task<IEnumerable<ZoneEntryDto>> GetEntriesAsync(int id, Predicate<Entry> predicate);
     }
 }

--- a/WarehouseManagement.Core/Services/ZoneService.cs
+++ b/WarehouseManagement.Core/Services/ZoneService.cs
@@ -197,6 +197,29 @@ public class ZoneService : IZoneService
         };
     }
 
+    public async Task<IEnumerable<ZoneEntryDto>> GetEntriesAsync(int id, Predicate<Entry> predicate)
+    {
+        // Check if this will include the entries
+        var currentZone = await this.repository.GetByIdAsync<Zone>(id);
+
+        if (currentZone == null)
+        {
+            throw new KeyNotFoundException(ZoneWithIdNotFound);
+        }
+
+        var entries = currentZone.Entries.Where(e => predicate(e));
+
+        return entries.Select(e => new ZoneEntryDto()
+        {
+            Pallets = e.Pallets,
+            Packages = e.Packages,
+            Pieces = e.Pieces,
+            StartedProccessing = e.StartedProccessing,
+            FinishedProccessing = e.FinishedProccessing,
+            DeliveryId = e.DeliveryId
+        });
+    }
+
     public async Task<string> RestoreAsync(int id)
     {
         var zone = await repository.All<Zone>().FirstOrDefaultAsync(v => v.Id == id);

--- a/WarehouseManagement.Core/Services/ZoneService.cs
+++ b/WarehouseManagement.Core/Services/ZoneService.cs
@@ -197,17 +197,64 @@ public class ZoneService : IZoneService
         };
     }
 
-    public async Task<IEnumerable<ZoneEntryDto>> GetEntriesAsync(int id, Predicate<Entry> predicate)
+    public async Task<IEnumerable<ZoneEntryDto>> GetFinishedEntries(int zoneId)
     {
-        // Check if this will include the entries
-        var currentZone = await this.repository.GetByIdAsync<Zone>(id);
+        var currentZone = await this.repository.GetByIdAsync<Zone>(zoneId);
 
         if (currentZone == null)
         {
             throw new KeyNotFoundException(ZoneWithIdNotFound);
         }
 
-        var entries = currentZone.Entries.Where(e => predicate(e));
+        var entries = currentZone.Entries.Where(e => e.FinishedProccessing != null);
+
+        return entries.Select(e => new ZoneEntryDto()
+        {
+            Pallets = e.Pallets,
+            Packages = e.Packages,
+            Pieces = e.Pieces,
+            StartedProccessing = e.StartedProccessing,
+            FinishedProccessing = e.FinishedProccessing,
+            DeliveryId = e.DeliveryId
+        });
+    }
+
+    public async Task<IEnumerable<ZoneEntryDto>> GetProccessingEntries(int zoneId)
+    {
+        var currentZone = await this.repository.GetByIdAsync<Zone>(zoneId);
+
+        if (currentZone == null)
+        {
+            throw new KeyNotFoundException(ZoneWithIdNotFound);
+        }
+
+        var entries = currentZone.Entries.Where(e =>
+            e.StartedProccessing != null && e.FinishedProccessing == null
+        );
+
+        return entries.Select(e => new ZoneEntryDto()
+        {
+            Pallets = e.Pallets,
+            Packages = e.Packages,
+            Pieces = e.Pieces,
+            StartedProccessing = e.StartedProccessing,
+            FinishedProccessing = e.FinishedProccessing,
+            DeliveryId = e.DeliveryId
+        });
+    }
+
+    public async Task<IEnumerable<ZoneEntryDto>> GetWaitingEntries(int zoneId)
+    {
+        var currentZone = await this.repository.GetByIdAsync<Zone>(zoneId);
+
+        if (currentZone == null)
+        {
+            throw new KeyNotFoundException(ZoneWithIdNotFound);
+        }
+
+        var entries = currentZone.Entries.Where(e =>
+            e.StartedProccessing == null && e.FinishedProccessing == null
+        );
 
         return entries.Select(e => new ZoneEntryDto()
         {


### PR DESCRIPTION
Adding endpoint '/entries' to zone where entries can be extracted with a provided status from the query parameter