### PR TITLE
Fix creation of zone and extracting markers

### DIFF
--- a/WarehouseManagement.Api/Controllers/MarkerController.cs
+++ b/WarehouseManagement.Api/Controllers/MarkerController.cs
@@ -30,7 +30,16 @@ public class MarkerController : ControllerBase
 
     [HttpGet("all")]
     [ProducesResponseType(200, Type = typeof(IEnumerable<MarkerDto>))]
-    public async Task<IActionResult> GetAll([FromQuery] PaginationParameters paginationParams)
+    public async Task<IActionResult> GetAll()
+    {
+        var model = await markerService.GetAllAsync();
+
+        return Ok(model);
+    }
+
+    [HttpGet("all-with-params")]
+    [ProducesResponseType(200, Type = typeof(IEnumerable<MarkerDto>))]
+    public async Task<IActionResult> GetAllWithParams([FromQuery] PaginationParameters paginationParams)
     {
         var model = await markerService.GetAllAsync(paginationParams);
 

--- a/WarehouseManagement.Api/Controllers/ZoneController.cs
+++ b/WarehouseManagement.Api/Controllers/ZoneController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using WarehouseManagement.Common.Statuses;
 using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Entry;
 using WarehouseManagement.Core.DTOs.Zone;
 using static WarehouseManagement.Common.MessageConstants.Keys.ZoneMessageKeys;
@@ -36,6 +37,15 @@ namespace WarehouseManagement.Api.Controllers
         public async Task<IActionResult> GetAll()
         {
             var zones = await zoneService.GetAllAsync();
+
+            return Ok(zones);
+        }
+
+        [HttpGet("all-with-params")]
+        [ProducesResponseType(200, Type = typeof(IEnumerable<ZoneDto>))]
+        public async Task<IActionResult> GetAllWithParams([FromQuery] PaginationParameters paginationParams)
+        {
+            var zones = await zoneService.GetAllAsync(paginationParams);
 
             return Ok(zones);
         }
@@ -93,6 +103,15 @@ namespace WarehouseManagement.Api.Controllers
         public async Task<IActionResult> AllWithDeleted()
         {
             var model = await zoneService.GetAllWithDeletedAsync();
+
+            return Ok(model);
+        }
+
+        [HttpGet("all-with-deleted-with-params")]
+        [ProducesResponseType(200, Type = typeof(IEnumerable<ZoneDto>))]
+        public async Task<IActionResult> AllWithDeletedWithParams([FromBody] PaginationParameters paginationParams)
+        {
+            var model = await zoneService.GetAllWithDeletedAsync(paginationParams);
 
             return Ok(model);
         }

--- a/WarehouseManagement.Core/Contracts/IMarkerService.cs
+++ b/WarehouseManagement.Core/Contracts/IMarkerService.cs
@@ -8,6 +8,7 @@ public interface IMarkerService
 {
     Task<MarkerDto> GetByIdAsync(int id);
     Task<bool> ExistByNameAsync(string name);
+    Task<IEnumerable<MarkerDto>> GetAllAsync();
     Task<IEnumerable<MarkerDto>> GetAllAsync(PaginationParameters paginationParams);
     Task<int> AddAsync(MarkerFormDto model, string userId);
     Task EditAsync(int id, MarkerFormDto model, string userId);

--- a/WarehouseManagement.Core/Contracts/IZoneService.cs
+++ b/WarehouseManagement.Core/Contracts/IZoneService.cs
@@ -1,4 +1,5 @@
-﻿using WarehouseManagement.Core.DTOs.Zone;
+﻿using WarehouseManagement.Core.DTOs;
+using WarehouseManagement.Core.DTOs.Zone;
 
 namespace WarehouseManagement.Core.Contracts
 {
@@ -6,7 +7,9 @@ namespace WarehouseManagement.Core.Contracts
     {
         Task<ZoneDto> GetByIdAsync(int id);
         Task<IEnumerable<ZoneDto>> GetAllAsync();
+        Task<IEnumerable<ZoneDto>> GetAllAsync(PaginationParameters paginationParams);
         Task<IEnumerable<ZoneDto>> GetAllWithDeletedAsync();
+        Task<IEnumerable<ZoneDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams);
         Task CreateAsync(ZoneFormDto model, string userId);
         Task EditAsync(int id, ZoneFormDto model, string userId);
         Task DeleteAsync(int id, string userId);

--- a/WarehouseManagement.Core/DTOs/Zone/ZoneDto.cs
+++ b/WarehouseManagement.Core/DTOs/Zone/ZoneDto.cs
@@ -6,6 +6,8 @@ public class ZoneDto
 
     public string Name { get; set; } = string.Empty;
 
+    public bool IsFinal { get; set; }
+
     public IEnumerable<ZoneMarkerDto> Markers { get; set; } = new HashSet<ZoneMarkerDto>();
 
     public IEnumerable<ZoneVendorDto> Vendors { get; set; } = new HashSet<ZoneVendorDto>();

--- a/WarehouseManagement.Core/DTOs/Zone/ZoneFormDto.cs
+++ b/WarehouseManagement.Core/DTOs/Zone/ZoneFormDto.cs
@@ -6,6 +6,11 @@ namespace WarehouseManagement.Core.DTOs.Zone;
 
 public class ZoneFormDto
 {
+    [Required]
     [StringLength(NameMaxLength, MinimumLength = NameMinLength, ErrorMessage = LengthErrorMessage)]
     public string Name { get; set; } = string.Empty;
+
+    public bool? IsFinal { get; set; }
+
+    public IEnumerable<int> MarkerIds { get; set; } = new List<int>();
 }

--- a/WarehouseManagement.Core/Services/MarkerService.cs
+++ b/WarehouseManagement.Core/Services/MarkerService.cs
@@ -91,6 +91,42 @@ public class MarkerService : IMarkerService
             .AnyAsync(m => m.Name.ToLower() == name.ToLower() && !m.IsDeleted);
     }
 
+    public async Task<IEnumerable<MarkerDto>> GetAllAsync()
+    {
+        var markers = await repository
+            .AllReadOnly<Marker>()
+            .Select(m => new MarkerDto
+            {
+                Id = m.Id,
+                Name = m.Name,
+                Deliveries = m
+                    .DeliveriesMarkers.Select(dm => new MarkerDeliveryDto
+                    {
+                        DeliveryId = dm.DeliveryId,
+                        DeliverySystemNumber = dm.Delivery.SystemNumber
+                    })
+                    .ToList(),
+                Vendors = m
+                    .VendorsMarkers.Select(vm => new MarkerVendorDto
+                    {
+                        VendorId = vm.VendorId,
+                        VendorName = vm.Vendor.Name,
+                        VendorSystemNumber = vm.Vendor.SystemNumber
+                    })
+                    .ToList(),
+                Zones = m
+                    .ZonesMarkers.Select(zm => new MarkerZoneDto
+                    {
+                        ZoneId = zm.ZoneId,
+                        ZoneName = zm.Zone.Name
+                    })
+                    .ToList()
+            })
+            .ToListAsync();
+
+        return markers;
+    }
+
     public async Task<IEnumerable<MarkerDto>> GetAllAsync(PaginationParameters paginationParams)
     {
         Expression<Func<Marker, bool>> filter = m =>

--- a/WarehouseManagement.Core/Services/ZoneService.cs
+++ b/WarehouseManagement.Core/Services/ZoneService.cs
@@ -1,6 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
 using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Zone;
+using WarehouseManagement.Core.Extensions;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
 using static WarehouseManagement.Common.MessageConstants.Keys.ZoneMessageKeys;
@@ -26,11 +29,27 @@ public class ZoneService : IZoneService
         var zone = new Zone()
         {
             Name = model.Name,
+            IsFinal = model.IsFinal ?? false,
             CreatedAt = DateTime.UtcNow,
             CreatedByUserId = userId
         };
 
         await repository.AddAsync(zone);
+
+        var markers = await repository
+            .All<Marker>()
+            .Where(m => model.MarkerIds.Contains(m.Id))
+            .ToListAsync();
+
+        foreach (var marker in markers)
+        {
+            await repository.AddAsync(new ZoneMarker()
+            {
+                Zone = zone,
+                Marker = marker
+            });
+        }
+
         await repository.SaveChangesAsync();
     }
 
@@ -105,6 +124,45 @@ public class ZoneService : IZoneService
             {
                 Id = z.Id,
                 Name = z.Name,
+                IsFinal = z.IsFinal,
+                Markers = z.ZonesMarkers.Select(zm => new ZoneMarkerDto()
+                {
+                    MarkerId = zm.MarkerId,
+                    MarkerName = zm.Marker.Name,
+                }),
+                Vendors = z.VendorsZones.Select(vz => new ZoneVendorDto()
+                {
+                    VendorId = vz.VendorId,
+                    VendorName = vz.Vendor.Name,
+                    VendorSystemNumber = vz.Vendor.SystemNumber
+                }),
+                Entries = z.Entries.Select(e => new ZoneEntryDto()
+                {
+                    EntryId = e.Id,
+                    Pallets = e.Pallets,
+                    Packages = e.Packages,
+                    Pieces = e.Pieces,
+                    StartedProccessing = e.StartedProccessing,
+                    FinishedProccessing = e.FinishedProccessing,
+                    DeliveryId = e.DeliveryId
+                })
+            })
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<ZoneDto>> GetAllAsync(PaginationParameters paginationParams)
+    {
+        Expression<Func<Zone, bool>> filter = z =>
+    EF.Functions.Like(z.Name, $"%{paginationParams.SearchQuery}%");
+
+        return await repository
+            .AllReadOnly<Zone>()
+            .Paginate(paginationParams, filter)
+            .Select(z => new ZoneDto()
+            {
+                Id = z.Id,
+                Name = z.Name,
+                IsFinal = z.IsFinal,
                 Markers = z.ZonesMarkers.Select(zm => new ZoneMarkerDto()
                 {
                     MarkerId = zm.MarkerId,
@@ -138,6 +196,45 @@ public class ZoneService : IZoneService
             {
                 Id = z.Id,
                 Name = z.Name,
+                IsFinal = z.IsFinal,
+                Markers = z.ZonesMarkers.Select(zm => new ZoneMarkerDto()
+                {
+                    MarkerId = zm.MarkerId,
+                    MarkerName = zm.Marker.Name,
+                }),
+                Vendors = z.VendorsZones.Select(vz => new ZoneVendorDto()
+                {
+                    VendorId = vz.VendorId,
+                    VendorName = vz.Vendor.Name,
+                    VendorSystemNumber = vz.Vendor.SystemNumber
+                }),
+                Entries = z.Entries.Select(e => new ZoneEntryDto()
+                {
+                    EntryId = e.Id,
+                    Pallets = e.Pallets,
+                    Packages = e.Packages,
+                    Pieces = e.Pieces,
+                    StartedProccessing = e.StartedProccessing,
+                    FinishedProccessing = e.FinishedProccessing,
+                    DeliveryId = e.DeliveryId
+                })
+            })
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<ZoneDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams)
+    {
+        Expression<Func<Zone, bool>> filter = z =>
+    EF.Functions.Like(z.Name, $"%{paginationParams.SearchQuery}%");
+
+        return await repository
+            .AllWithDeletedReadOnly<Zone>()
+            .Paginate(paginationParams, filter)
+            .Select(z => new ZoneDto()
+            {
+                Id = z.Id,
+                Name = z.Name,
+                IsFinal = z.IsFinal,
                 Markers = z.ZonesMarkers.Select(zm => new ZoneMarkerDto()
                 {
                     MarkerId = zm.MarkerId,
@@ -176,6 +273,7 @@ public class ZoneService : IZoneService
         {
             Id = zone.Id,
             Name = zone.Name,
+            IsFinal = zone.IsFinal,
             Markers = zone.ZonesMarkers.Select(zm => new ZoneMarkerDto()
             {
                 MarkerId = zm.MarkerId,


### PR DESCRIPTION
Adding properties to ZoneFormDto, fixing the creation of zone and adding overload methods for extracting all zones/markers to prevent the default behavior of the PageParameters.