### PR TITLE
Fix ID parameter in GetHistory action for deliveries

### DIFF
--- a/WarehouseManagement.Api/Controllers/DeliveryController.cs
+++ b/WarehouseManagement.Api/Controllers/DeliveryController.cs
@@ -135,7 +135,7 @@ public class DeliveryController : ControllerBase
     [HttpGet("history/{id}")]
     [ProducesResponseType(200, Type = typeof(DeliveryHistoryDto))]
     [ProducesResponseType(404)]
-    public async Task<IActionResult> GetHistory([FromQuery] int id)
+    public async Task<IActionResult> GetHistory(int id)
     {
         var history = await deliveryService.GetHistoryAsync(id);
 


### PR DESCRIPTION
Fixed the mistake where Id was expected to be passed as route param and as query param. Now it is only extracted from the route.