### PR TITLE
Add page model on returning entities which require pagination

### DIFF
--- a/Warehouse.Management.Tests/DifferenceServiceTests.cs
+++ b/Warehouse.Management.Tests/DifferenceServiceTests.cs
@@ -281,9 +281,9 @@ public class DifferenceServiceTests
     {
         var paginationParams = new PaginationParameters { PageNumber = 1, PageSize = 10 };
 
-        var result = await differenceService.GetAllAsync(paginationParams);
+        var model = await differenceService.GetAllAsync(paginationParams);
 
-        Assert.That(result.Count(), Is.EqualTo(3));
+        Assert.That(model.Results.Count(), Is.EqualTo(3));
     }
 
     [Test]
@@ -297,7 +297,7 @@ public class DifferenceServiceTests
 
         var result = await differenceService.GetAllWithDeletedAsync(paginationParams);
 
-        Assert.That(result.Count(), Is.EqualTo(ExpectedTotalDifferencesCount));
+        Assert.That(result.Results.Count(), Is.EqualTo(ExpectedTotalDifferencesCount));
     }
 
     [Test]

--- a/Warehouse.Management.Tests/EntryServiceTests.cs
+++ b/Warehouse.Management.Tests/EntryServiceTests.cs
@@ -11,6 +11,7 @@ using WarehouseManagement.Common.Statuses;
 using static WarehouseManagement.Common.MessageConstants.Keys.EntryMessageKey;
 using static WarehouseManagement.Common.MessageConstants.Keys.ZoneMessageKeys;
 using Castle.Components.DictionaryAdapter.Xml;
+using WarehouseManagement.Core.DTOs;
 
 namespace Warehouse.Management.Tests;
 
@@ -267,57 +268,57 @@ public class EntryServiceTests
     [Test]
     public async Task GetAllAsync_ShouldReturnAllEntries()
     {
-        var entries = await entryService.GetAllAsync();
+        var entries = await entryService.GetAllAsync(new PaginationParameters());
 
-        Assert.That(entries.Count(), Is.EqualTo(3));
+        Assert.That(entries.Results.Count(), Is.EqualTo(3));
     }
 
     [Test]
     public async Task GetAllAsync_ShouldReturnAllEntries_WithTheProvidedStatus()
     {
-        var entries = await entryService.GetAllAsync([EntryStatuses.Waiting]);
+        var entries = await entryService.GetAllAsync(new PaginationParameters(), [EntryStatuses.Waiting]);
 
-        Assert.That(entries.Count(), Is.EqualTo(1));
+        Assert.That(entries.Results.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public async Task GetAllByZoneAsync_ShouldReturnAllEntries_ForTheGivenZone()
     {
-        var entries = await entryService.GetAllByZoneAsync(1);
+        var entries = await entryService.GetAllByZoneAsync(new PaginationParameters(), 1);
 
-        Assert.That(entries.Count(), Is.EqualTo(2));
+        Assert.That(entries.Results.Count(), Is.EqualTo(2));
     }
 
     [Test]
     public async Task GetAllByZoneAsync_ShouldReturnAllEntries_WithTheProvidedStatus_ForTheGivenZone()
     {
-        var entries = await entryService.GetAllByZoneAsync(1, [EntryStatuses.Waiting]);
+        var entries = await entryService.GetAllByZoneAsync(new PaginationParameters(), 1, [EntryStatuses.Waiting]);
 
-        Assert.That(entries.Count(), Is.EqualTo(1));
+        Assert.That(entries.Results.Count(), Is.EqualTo(1));
     }
 
     [Test]
     public async Task GetAllWithDeletedAsync_ShouldReturnAllEntries_IncludingTheDeleted()
     {
-        var entries = await entryService.GetAllWithDeletedAsync();
+        var entries = await entryService.GetAllWithDeletedAsync(new PaginationParameters());
 
-        Assert.That(entries.Count(), Is.EqualTo(4));
+        Assert.That(entries.Results.Count(), Is.EqualTo(4));
     }
 
     [Test]
     public async Task GetAllWithDeletedAsync_ShouldReturnAllEntries_IncludingTheDeleted_ForTheGivenZone_WheZoneIdIsProvided()
     {
-        var entries = await entryService.GetAllWithDeletedAsync(1);
+        var entries = await entryService.GetAllWithDeletedAsync(new PaginationParameters(), 1);
 
-        Assert.That(entries.Count(), Is.EqualTo(3));
+        Assert.That(entries.Results.Count(), Is.EqualTo(3));
     }
 
     [Test]
     public async Task GetAllWithDeletedAsync_ShouldReturnAllEntries_IncludingTheDeleted_ForTheGivenZone_WithTheProvidedStatus()
     {
-        var entries = await entryService.GetAllWithDeletedAsync(1, [EntryStatuses.Waiting]);
+        var entries = await entryService.GetAllWithDeletedAsync(new PaginationParameters(), 1, [EntryStatuses.Waiting]);
 
-        Assert.That(entries.Count(), Is.EqualTo(2));
+        Assert.That(entries.Results.Count(), Is.EqualTo(2));
     }
 
     [Test]

--- a/Warehouse.Management.Tests/ZoneServiceTests.cs
+++ b/Warehouse.Management.Tests/ZoneServiceTests.cs
@@ -314,7 +314,7 @@ public class ZoneServiceTests
     {
         var zones = await zoneService.GetAllWithDeletedAsync();
 
-        Assert.That(zones.Count, Is.EqualTo(3));
+        Assert.That(zones.Count, Is.EqualTo(4));
     }
 
     [Test]

--- a/WarehouseManagement.Api/Controllers/DeliveryController.cs
+++ b/WarehouseManagement.Api/Controllers/DeliveryController.cs
@@ -40,7 +40,7 @@ public class DeliveryController : ControllerBase
     }
 
     [HttpGet("all")]
-    [ProducesResponseType(200, Type = typeof(ICollection<DeliveryDto>))]
+    [ProducesResponseType(200, Type = typeof(PageDto<DeliveryDto>))]
     public async Task<IActionResult> GetDeliveries(
         [FromQuery] PaginationParameters paginationParams
     )

--- a/WarehouseManagement.Api/Controllers/DifferenceController.cs
+++ b/WarehouseManagement.Api/Controllers/DifferenceController.cs
@@ -19,21 +19,21 @@ public class DifferenceController : ControllerBase
     }
 
     [HttpGet("all")]
-    [ProducesResponseType(200, Type = typeof(IEnumerable<DifferenceDto>))]
+    [ProducesResponseType(200, Type = typeof(PageDto<DifferenceDto>))]
     public async Task<IActionResult> All([FromQuery] PaginationParameters paginationParams)
     {
-        var models = await differenceService.GetAllAsync(paginationParams);
+        var pageDto = await differenceService.GetAllAsync(paginationParams);
 
-        return Ok(models);
+        return Ok(pageDto);
     }
 
     [HttpGet("all-with-deleted")]
-    [ProducesResponseType(200, Type = typeof(IEnumerable<DifferenceDto>))]
+    [ProducesResponseType(200, Type = typeof(PageDto<DifferenceDto>))]
     public async Task<IActionResult> AllWithDeleted([FromQuery] PaginationParameters paginationParams)
     {
-        var models = await differenceService.GetAllWithDeletedAsync(paginationParams);
+        var pageDto = await differenceService.GetAllWithDeletedAsync(paginationParams);
 
-        return Ok(models);
+        return Ok(pageDto);
     }
 
     [HttpGet("{id}")]

--- a/WarehouseManagement.Api/Controllers/EntryController.cs
+++ b/WarehouseManagement.Api/Controllers/EntryController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Mvc;
 using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Entry;
 using WarehouseManagement.Core.DTOs.Requests;
 using static WarehouseManagement.Common.MessageConstants.Keys.EntryMessageKey;
@@ -21,17 +22,17 @@ namespace WarehouseManagement.Api.Controllers
         }
 
         [HttpGet("all")]
-        [ProducesResponseType(200, Type = typeof(IEnumerable<EntryDto>))]
-        public async Task<IActionResult> All([FromQuery] EntryRequest request)
+        [ProducesResponseType(200, Type = typeof(PageDto<EntryDto>))]
+        public async Task<IActionResult> All([FromQuery] PaginationParameters paginationParams, [FromQuery] EntryRequest request)
         {
             if (request.ZoneId != null)
             {
                 return Ok(
-                    await entryService.GetAllByZoneAsync((int)request.ZoneId, request.Statuses)
+                    await entryService.GetAllByZoneAsync(paginationParams, (int)request.ZoneId, request.Statuses)
                 );
             }
 
-            return Ok(await entryService.GetAllAsync(request.Statuses));
+            return Ok(await entryService.GetAllAsync(paginationParams, request.Statuses));
         }
 
         [HttpGet("{id}")]
@@ -46,14 +47,15 @@ namespace WarehouseManagement.Api.Controllers
 
         [HttpGet("all-with-deleted")]
         [ProducesResponseType(200, Type = typeof(IEnumerable<EntryDto>))]
-        public async Task<IActionResult> AllWithDeleted([FromBody] EntryRequest request)
+        public async Task<IActionResult> AllWithDeleted([FromQuery] PaginationParameters paginationParams, [FromQuery] EntryRequest request)
         {
-            var entries = await entryService.GetAllWithDeletedAsync(
+            var pageDto = await entryService.GetAllWithDeletedAsync(
+                paginationParams,
                 request.ZoneId,
                 request.Statuses
             );
 
-            return Ok(entries);
+            return Ok(pageDto);
         }
 
         [HttpPost("add")]

--- a/WarehouseManagement.Api/Controllers/ZoneController.cs
+++ b/WarehouseManagement.Api/Controllers/ZoneController.cs
@@ -117,13 +117,13 @@ namespace WarehouseManagement.Api.Controllers
         }
 
         [HttpGet("entries")]
-        [ProducesResponseType(200, Type = typeof(IEnumerable<EntryDto>))]
+        [ProducesResponseType(200, Type = typeof(PageDto<EntryDto>))]
         [ProducesResponseType(404)]
-        public async Task<IActionResult> Entries(int zoneId, [FromQuery] EntryStatuses[]? statuses)
+        public async Task<IActionResult> Entries(int zoneId, [FromQuery] EntryStatuses[]? statuses, [FromQuery] PaginationParameters paginationParams)
         {
-            IEnumerable<EntryDto> entries = await entryService.GetAllByZoneAsync(zoneId, statuses);
+            var pageDto = await entryService.GetAllByZoneAsync(paginationParams, zoneId, statuses);
 
-            return Ok(entries);
+            return Ok(pageDto);
         }
     }
 }

--- a/WarehouseManagement.Core/Contracts/IDeliveryService.cs
+++ b/WarehouseManagement.Core/Contracts/IDeliveryService.cs
@@ -6,7 +6,7 @@ namespace WarehouseManagement.Core.Contracts;
 public interface IDeliveryService
 {
     Task<DeliveryDto> GetByIdAsync(int id);
-    Task<ICollection<DeliveryDto>> GetAllAsync(PaginationParameters paginationParams);
+    Task<PageDto<DeliveryDto>> GetAllAsync(PaginationParameters paginationParams);
     Task EditAsync(int id, DeliveryFormDto model, string userId);
     Task<int> AddAsync(DeliveryFormDto model, string userId);
     Task DeleteAsync(int id);

--- a/WarehouseManagement.Core/Contracts/IDifferenceService.cs
+++ b/WarehouseManagement.Core/Contracts/IDifferenceService.cs
@@ -7,9 +7,9 @@ public interface IDifferenceService
 {
     Task<DifferenceDto> GetByIdAsync(int id);
 
-    Task<IEnumerable<DifferenceDto>> GetAllAsync(PaginationParameters paginationParams);
+    Task<PageDto<DifferenceDto>> GetAllAsync(PaginationParameters paginationParams);
 
-    Task<IEnumerable<DifferenceDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams);
+    Task<PageDto<DifferenceDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams);
 
     Task CreateAsync(DifferenceFormDto model, string userId);
 

--- a/WarehouseManagement.Core/Contracts/IEntryService.cs
+++ b/WarehouseManagement.Core/Contracts/IEntryService.cs
@@ -1,4 +1,5 @@
 ﻿using WarehouseManagement.Common.Statuses;
+using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Entry;
 
 namespace WarehouseManagement.Core.Contracts;
@@ -6,9 +7,9 @@ namespace WarehouseManagement.Core.Contracts;
 public interface IEntryService
 {
     Task<EntryDto> GetByIdAsync(int id);
-    Task<IEnumerable<EntryDto>> GetAllAsync(EntryStatuses[]? statuses = null);
-    Task<IEnumerable<EntryDto>> GetAllByZoneAsync(int zoneId, EntryStatuses[]? statuses = null);
-    Task<IEnumerable<EntryDto>> GetAllWithDeletedAsync(int? zoneId = null, EntryStatuses[]? statuses = null);
+    Task<PageDto<EntryDto>> GetAllAsync(PaginationParameters paginationParams, EntryStatuses[]? statuses = null);
+    Task<PageDto<EntryDto>> GetAllByZoneAsync(PaginationParameters paginationParams, int zoneId, EntryStatuses[]? statuses = null);
+    Task<PageDto<EntryDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams, int? zoneId = null, EntryStatuses[]? statuses = null);
     Task CreateAsync(ICollection<EntryFormDto> model, string userId);
     Task EditAsync(int id, EntryFormDto model, string userId);
     Task DeleteAsync(int id, string userId);

--- a/WarehouseManagement.Core/DTOs/Delivery/DeliveryDto.cs
+++ b/WarehouseManagement.Core/DTOs/Delivery/DeliveryDto.cs
@@ -1,4 +1,6 @@
-﻿namespace WarehouseManagement.Core.DTOs.Delivery;
+﻿using WarehouseManagement.Core.DTOs.Entry;
+
+namespace WarehouseManagement.Core.DTOs.Delivery;
 
 public class DeliveryDto
 {
@@ -17,6 +19,6 @@ public class DeliveryDto
     public int VendorId { get; set; }
     public string VendorName { get; set; } = string.Empty;
     public string Status { get; set; } = string.Empty;
-    public ICollection<DeliveryEntryDto> Entries { get; set; } = new List<DeliveryEntryDto>();
+    public ICollection<EntryDto> Entries { get; set; } = new List<EntryDto>();
     public ICollection<DeliveryMarkerDto> Markers { get; set; } = new List<DeliveryMarkerDto>();
 }

--- a/WarehouseManagement.Core/DTOs/Entry/EntryDto.cs
+++ b/WarehouseManagement.Core/DTOs/Entry/EntryDto.cs
@@ -1,4 +1,6 @@
-﻿namespace WarehouseManagement.Core.DTOs.Entry;
+﻿using WarehouseManagement.Core.DTOs.Zone;
+
+namespace WarehouseManagement.Core.DTOs.Entry;
 
 public class EntryDto
 {
@@ -8,6 +10,6 @@ public class EntryDto
     public int Pieces { get; set; }
     public DateTime? StartedProccessing { get; set; }
     public DateTime? FinishedProccessing { get; set; }
-    public int ZoneId { get; set; }
+    public ZoneDto Zone { get; set; } = null!;
     public int DeliveryId { get; set; }
 }

--- a/WarehouseManagement.Core/DTOs/PageDto.cs
+++ b/WarehouseManagement.Core/DTOs/PageDto.cs
@@ -1,0 +1,9 @@
+﻿namespace WarehouseManagement.Core.DTOs;
+
+public class PageDto<T>
+    where T : class
+{
+    public int Count { get; set; }
+
+    public IEnumerable<T> Results { get; set; } = new HashSet<T>();
+}

--- a/WarehouseManagement.Core/DTOs/PageDto.cs
+++ b/WarehouseManagement.Core/DTOs/PageDto.cs
@@ -6,4 +6,8 @@ public class PageDto<T>
     public int Count { get; set; }
 
     public IEnumerable<T> Results { get; set; } = new HashSet<T>();
+
+    public bool HasPrevious { get; set; }
+
+    public bool HasNext { get; set; }
 }

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -139,10 +139,14 @@ public class DeliveryService : IDeliveryService
             })
             .ToListAsync();
 
+        var totalItems = repository.AllReadOnly<Delivery>().Count();
+
         return new PageDto<DeliveryDto>()
         {
-            Count = repository.AllReadOnly<Delivery>().Count(),
-            Results = deliveries
+            Count = totalItems,
+            Results = deliveries,
+            HasPrevious = paginationParams.PageNumber > 1,
+            HasNext = paginationParams.PageNumber * paginationParams.PageSize < totalItems
         };
     }
 

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -82,7 +82,7 @@ public class DeliveryService : IDeliveryService
         return delivery;
     }
 
-    public async Task<ICollection<DeliveryDto>> GetAllAsync(PaginationParameters paginationParams)
+    public async Task<PageDto<DeliveryDto>> GetAllAsync(PaginationParameters paginationParams)
     {
         Expression<Func<Delivery, bool>> filter = v =>
             EF.Functions.Like(v.ReceptionNumber, $"%{paginationParams.SearchQuery}%")
@@ -139,7 +139,11 @@ public class DeliveryService : IDeliveryService
             })
             .ToListAsync();
 
-        return deliveries;
+        return new PageDto<DeliveryDto>()
+        {
+            Count = repository.AllReadOnly<Delivery>().Count(),
+            Results = deliveries
+        };
     }
 
     public async Task EditAsync(int id, DeliveryFormDto model, string userId)

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -5,11 +5,12 @@ using WarehouseManagement.Common.Statuses;
 using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Delivery;
+using WarehouseManagement.Core.DTOs.Entry;
+using WarehouseManagement.Core.DTOs.Zone;
 using WarehouseManagement.Core.Extensions;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
 using static WarehouseManagement.Common.MessageConstants.Keys.DeliveryMessageKeys;
-using static WarehouseManagement.Core.DTOs.Delivery.DeliveryHistoryDto;
 
 namespace WarehouseManagement.Core.Services;
 
@@ -40,22 +41,23 @@ public class DeliveryService : IDeliveryService
                 TruckNumber = d.TruckNumber,
                 VendorId = d.VendorId,
                 VendorName = d.Vendor.Name,
-                Status = d.Entries.Any()
-                    ? d.Entries.All(e => e.FinishedProcessing.HasValue)
-                        ? d.IsApproved
-                            ? DeliveryStatus.Approved.ToString()
-                            : DeliveryStatus.Finished.ToString()
-                        : d.Entries.Any(e => e.StartedProcessing.HasValue)
-                            ? DeliveryStatus.Processing.ToString()
-                            : DeliveryStatus.Waiting.ToString()
-                    : DeliveryStatus.Waiting.ToString(),
+                Status = d.Status.ToString(),
                 Entries = d
-                    .Entries.Select(e => new DeliveryEntryDto()
+                    .Entries.Select(e => new EntryDto()
                     {
                         Id = e.Id,
+                        Packages = e.Packages,
+                        Pallets = e.Pallets,
+                        Pieces = e.Pieces,
                         FinishedProccessing = e.FinishedProcessing,
                         StartedProccessing = e.StartedProcessing,
-                        ZoneId = e.ZoneId
+                        Zone = new ZoneDto()
+                        {
+                            Id = e.ZoneId,
+                            Name = e.Zone.Name,
+                            IsFinal = e.Zone.IsFinal
+                        },
+                        DeliveryId = e.DeliveryId,
                     })
                     .ToList(),
                 Markers = d
@@ -106,22 +108,23 @@ public class DeliveryService : IDeliveryService
                 TruckNumber = d.TruckNumber,
                 VendorId = d.VendorId,
                 VendorName = d.Vendor.Name,
-                Status = d.Entries.Any()
-                    ? d.Entries.All(e => e.FinishedProcessing.HasValue)
-                        ? d.IsApproved
-                            ? DeliveryStatus.Approved.ToString()
-                            : DeliveryStatus.Finished.ToString()
-                        : d.Entries.Any(e => e.StartedProcessing.HasValue)
-                            ? DeliveryStatus.Processing.ToString()
-                            : DeliveryStatus.Waiting.ToString()
-                    : DeliveryStatus.Waiting.ToString(),
+                Status = d.Status.ToString(),
                 Entries = d
-                    .Entries.Select(e => new DeliveryEntryDto()
+                    .Entries.Select(e => new EntryDto()
                     {
                         Id = e.Id,
+                        Packages = e.Packages,
+                        Pallets = e.Pallets,
+                        Pieces = e.Pieces,
                         FinishedProccessing = e.FinishedProcessing,
                         StartedProccessing = e.StartedProcessing,
-                        ZoneId = e.ZoneId
+                        Zone = new ZoneDto()
+                        {
+                            Id = e.ZoneId,
+                            Name = e.Zone.Name,
+                            IsFinal = e.Zone.IsFinal
+                        },
+                        DeliveryId = e.DeliveryId,
                     })
                     .ToList(),
                 Markers = d
@@ -278,22 +281,23 @@ public class DeliveryService : IDeliveryService
                 TruckNumber = d.TruckNumber,
                 VendorId = d.VendorId,
                 VendorName = d.Vendor.Name,
-                Status = d.Entries.Any()
-                    ? d.Entries.All(e => e.FinishedProcessing.HasValue)
-                        ? d.IsApproved
-                            ? DeliveryStatus.Approved.ToString()
-                            : DeliveryStatus.Finished.ToString()
-                        : d.Entries.Any(e => e.StartedProcessing.HasValue)
-                            ? DeliveryStatus.Processing.ToString()
-                            : DeliveryStatus.Waiting.ToString()
-                    : DeliveryStatus.Waiting.ToString(),
+                Status = d.Status.ToString(),
                 Entries = d
-                    .Entries.Select(e => new DeliveryEntryDto()
+                    .Entries.Select(e => new EntryDto()
                     {
                         Id = e.Id,
+                        Packages = e.Packages,
+                        Pallets = e.Pallets,
+                        Pieces = e.Pieces,
                         FinishedProccessing = e.FinishedProcessing,
                         StartedProccessing = e.StartedProcessing,
-                        ZoneId = e.ZoneId
+                        Zone = new ZoneDto()
+                        {
+                            Id = e.ZoneId,
+                            Name = e.Zone.Name,
+                            IsFinal = e.Zone.IsFinal
+                        },
+                        DeliveryId = e.DeliveryId,
                     })
                     .ToList(),
                 Markers = d

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -341,22 +341,24 @@ public class DeliveryService : IDeliveryService
     {
         var delivery = await RetrieveByIdAsync(id);
 
-        var relatedEntriesIds = repository
+        var relatedEntriesIds = await repository
             .AllReadOnly<Entry>()
             .Where(e => e.DeliveryId == delivery.Id)
-            .Select(e => e.Id);
+            .Select(e => e.Id)
+            .ToListAsync();
 
-        var changes = repository
+        var changes = await repository
             .AllReadOnly<EntityChange>()
             .Where(change =>
                 int.Parse(change.EntityId) == delivery.Id
                 || relatedEntriesIds.Any(id => id == int.Parse(change.EntityId))
-            );
+            )
+            .ToListAsync();
 
         var deliveryHistory = new DeliveryHistoryDto
         {
             Id = delivery.Id,
-            Changes = await changes
+            Changes = changes
                 .Select(change => new DeliveryHistoryDto.Change
                 {
                     EntityId = int.Parse(change.EntityId),
@@ -381,7 +383,7 @@ public class DeliveryService : IDeliveryService
                                     : LogType.Split, // May be refactored based on the Move functionality
                     ChangeDate = change.ChangedAt
                 })
-                .ToListAsync()
+                .ToList()
         };
 
         return deliveryHistory;

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -9,6 +9,7 @@ using WarehouseManagement.Core.Extensions;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
 using static WarehouseManagement.Common.MessageConstants.Keys.DeliveryMessageKeys;
+using static WarehouseManagement.Core.DTOs.Delivery.DeliveryHistoryDto;
 
 namespace WarehouseManagement.Core.Services;
 
@@ -349,11 +350,12 @@ public class DeliveryService : IDeliveryService
 
         var changes = await repository
             .AllReadOnly<EntityChange>()
-            .Where(change =>
-                int.Parse(change.EntityId) == delivery.Id
-                || relatedEntriesIds.Any(id => id == int.Parse(change.EntityId))
-            )
             .ToListAsync();
+
+        changes = changes
+            .Where(change => int.Parse(change.EntityId) == delivery.Id ||
+                relatedEntriesIds.Any(id => id == int.Parse(change.EntityId)))
+            .ToList();
 
         var deliveryHistory = new DeliveryHistoryDto
         {

--- a/WarehouseManagement.Core/Services/DifferenceService.cs
+++ b/WarehouseManagement.Core/Services/DifferenceService.cs
@@ -105,10 +105,14 @@ public class DifferenceService : IDifferenceService
                 DeliverySystemNumber = d.Delivery.SystemNumber
             }).ToListAsync();
 
+        var totalItems = repository.AllReadOnly<Difference>().Count();
+
         return new PageDto<DifferenceDto>()
         {
-            Count = repository.AllReadOnly<Difference>().Count(),
-            Results = differences
+            Count = totalItems,
+            Results = differences,
+            HasPrevious = paginationParams.PageNumber > 1,
+            HasNext = paginationParams.PageNumber * paginationParams.PageSize < totalItems
         };
     }
 
@@ -137,10 +141,14 @@ public class DifferenceService : IDifferenceService
                 DeliverySystemNumber = d.Delivery.SystemNumber
             }).ToListAsync();
 
+        var totalItems = repository.AllReadOnly<Difference>().Count();
+
         return new PageDto<DifferenceDto>()
         {
-            Count = repository.AllReadOnly<Difference>().Count(),
-            Results = differences
+            Count = totalItems,
+            Results = differences,
+            HasPrevious = paginationParams.PageNumber > 1,
+            HasNext = paginationParams.PageNumber * paginationParams.PageSize < totalItems
         };
     }
 

--- a/WarehouseManagement.Core/Services/DifferenceService.cs
+++ b/WarehouseManagement.Core/Services/DifferenceService.cs
@@ -80,14 +80,14 @@ public class DifferenceService : IDifferenceService
         return await repository.GetByIdAsync<Difference>(id) != null;
     }
 
-    public async Task<IEnumerable<DifferenceDto>> GetAllAsync(PaginationParameters paginationParams)
+    public async Task<PageDto<DifferenceDto>> GetAllAsync(PaginationParameters paginationParams)
     {
         Expression<Func<Difference, bool>> filter = v =>
             EF.Functions.Like(v.ReceptionNumber, $"%{paginationParams.SearchQuery}%")
             || EF.Functions.Like(v.InternalNumber, $"%{paginationParams.SearchQuery}%")
             || EF.Functions.Like(v.ActiveNumber, $"%{paginationParams.SearchQuery}%");
 
-        var models = await repository
+        var differences = await repository
             .AllReadOnly<Difference>()
             .Paginate(paginationParams, filter)
             .Select(d => new DifferenceDto()
@@ -105,17 +105,21 @@ public class DifferenceService : IDifferenceService
                 DeliverySystemNumber = d.Delivery.SystemNumber
             }).ToListAsync();
 
-        return models;
+        return new PageDto<DifferenceDto>()
+        {
+            Count = repository.AllReadOnly<Difference>().Count(),
+            Results = differences
+        };
     }
 
-    public async Task<IEnumerable<DifferenceDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams)
+    public async Task<PageDto<DifferenceDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams)
     {
         Expression<Func<Difference, bool>> filter = v =>
             EF.Functions.Like(v.ReceptionNumber, $"%{paginationParams.SearchQuery}%")
             || EF.Functions.Like(v.InternalNumber, $"%{paginationParams.SearchQuery}%")
             || EF.Functions.Like(v.ActiveNumber, $"%{paginationParams.SearchQuery}%");
 
-        var models = await repository
+        var differences = await repository
             .AllWithDeletedReadOnly<Difference>()
             .Paginate(paginationParams, filter)
             .Select(d => new DifferenceDto()
@@ -133,7 +137,11 @@ public class DifferenceService : IDifferenceService
                 DeliverySystemNumber = d.Delivery.SystemNumber
             }).ToListAsync();
 
-        return models;
+        return new PageDto<DifferenceDto>()
+        {
+            Count = repository.AllReadOnly<Difference>().Count(),
+            Results = differences
+        };
     }
 
     public async Task<DifferenceDto> GetByIdAsync(int id)

--- a/WarehouseManagement.Core/Services/EntryService.cs
+++ b/WarehouseManagement.Core/Services/EntryService.cs
@@ -4,11 +4,12 @@ using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs.Entry;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
+using WarehouseManagement.Core.DTOs;
+using WarehouseManagement.Core.Extensions;
 using static WarehouseManagement.Common.MessageConstants.Keys.EntryMessageKey;
 using static WarehouseManagement.Common.MessageConstants.Keys.ZoneMessageKeys;
 using static WarehouseManagement.Common.MessageConstants.Keys.DeliveryMessageKeys;
-using WarehouseManagement.Core.DTOs;
-using WarehouseManagement.Core.Extensions;
+using WarehouseManagement.Core.DTOs.Zone;
 
 namespace WarehouseManagement.Core.Services;
 
@@ -89,7 +90,12 @@ public class EntryService : IEntryService
                 Pieces = e.Pieces,
                 StartedProccessing = e.StartedProcessing,
                 FinishedProccessing = e.FinishedProcessing,
-                ZoneId = e.ZoneId,
+                Zone = new ZoneDto()
+                {
+                    Id = e.ZoneId,
+                    Name = e.Zone.Name,
+                    IsFinal = e.Zone.IsFinal
+                },
                 DeliveryId = e.DeliveryId
             })
             .ToListAsync();
@@ -124,7 +130,12 @@ public class EntryService : IEntryService
                 Pieces = e.Pieces,
                 StartedProccessing = e.StartedProcessing,
                 FinishedProccessing = e.FinishedProcessing,
-                ZoneId = e.ZoneId,
+                Zone = new ZoneDto()
+                {
+                    Id = e.ZoneId,
+                    Name = e.Zone.Name,
+                    IsFinal = e.Zone.IsFinal
+                },
                 DeliveryId = e.DeliveryId
             })
             .ToListAsync();
@@ -163,7 +174,12 @@ public class EntryService : IEntryService
                 Pieces = e.Pieces,
                 StartedProccessing = e.StartedProcessing,
                 FinishedProccessing = e.FinishedProcessing,
-                ZoneId = e.ZoneId,
+                Zone = new ZoneDto()
+                {
+                    Id = e.ZoneId,
+                    Name = e.Zone.Name,
+                    IsFinal = e.Zone.IsFinal
+                },
                 DeliveryId = e.DeliveryId
             })
             .ToListAsync();
@@ -196,7 +212,12 @@ public class EntryService : IEntryService
             Pieces = entry.Pieces,
             StartedProccessing = entry.StartedProcessing,
             FinishedProccessing = entry.FinishedProcessing,
-            ZoneId = entry.ZoneId,
+            Zone = new ZoneDto()
+            {
+                Id = entry.ZoneId,
+                Name = entry.Zone.Name,
+                IsFinal = entry.Zone.IsFinal
+            },
             DeliveryId = entry.DeliveryId
         };
     }


### PR DESCRIPTION
When retrieving `Differences` or `Deliveries` the response will contain the total count of the models in a property called `Count` and in the `Results` property there will be the models for the currently selected page.