### PR TITLE
Add JWT authentication with refresh tokens

### DIFF
--- a/WarehouseManagement.Api/Controllers/AuthController.cs
+++ b/WarehouseManagement.Api/Controllers/AuthController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs.Auth;
+using static WarehouseManagement.Common.MessageConstants.Keys.AuthMassegeKeys;
 
 namespace WarehouseManagement.Api.Controllers;
 
@@ -16,9 +18,9 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("login")]
-    [ProducesResponseType(200, Type = typeof(string))]
+    [ProducesResponseType(200, Type = typeof(TokenResponse))]
     [ProducesResponseType(500)]
-    public async Task<IActionResult> Login([FromBody] LoginDto logindDto)
+    public async Task<IActionResult> SignIn([FromBody] LoginDto logindDto)
     {
         if (!ModelState.IsValid)
         {
@@ -26,22 +28,48 @@ public class AuthController : ControllerBase
         }
 
         string jwtToken = await authService.LoginAsync(logindDto);
+        string refreshToken = await authService.GenerateRefreshToken(User.Id());
 
-        return Ok(jwtToken);
+        return Ok(new TokenResponse() { AccessToken = jwtToken, RefreshToken = refreshToken });
     }
 
     [HttpPost("register")]
     [ProducesResponseType(200, Type = typeof(string))]
     [ProducesResponseType(500)]
-    public async Task<IActionResult> Register([FromBody] RegisterDto registerDto)
+    public async Task<IActionResult> SignUp([FromBody] RegisterDto registerDto)
     {
         if (!ModelState.IsValid)
         {
             return BadRequest(ModelState);
         }
 
-        string jwtToken = await authService.RegisterAsync(registerDto);
+        await authService.RegisterAsync(registerDto);
 
-        return Ok(jwtToken);
+        return Ok(UserRegisteredSuccessfully);
+    }
+
+    [HttpPost("refresh")]
+    [ProducesResponseType(200, Type = typeof(TokenResponse))]
+    [ProducesResponseType(400)]
+    [ProducesResponseType(404)]
+    public async Task<IActionResult> Refresh([FromBody] string refreshToken)
+    {
+        var newAccessToken = await authService.GenerateAccessTokenFromRefreshToken(refreshToken);
+
+        var response = new TokenResponse
+        {
+            AccessToken = newAccessToken,
+            RefreshToken = refreshToken
+        };
+
+        return Ok(response);
+    }
+
+    [HttpPost("/logout")]
+    public async Task<IActionResult> Logout()
+    {
+        await authService.LogoutAsync(User.Id());
+
+        return Ok(UserSignedOutSuccessfully);
     }
 }

--- a/WarehouseManagement.Api/Controllers/AuthController.cs
+++ b/WarehouseManagement.Api/Controllers/AuthController.cs
@@ -11,10 +11,12 @@ namespace WarehouseManagement.Api.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly IAuthService authService;
+    private readonly IJwtService jwtService;
 
-    public AuthController(IAuthService authService)
+    public AuthController(IAuthService authService, IJwtService jwtService)
     {
         this.authService = authService;
+        this.jwtService = jwtService;
     }
 
     [HttpPost("login")]
@@ -28,7 +30,7 @@ public class AuthController : ControllerBase
         }
 
         string jwtToken = await authService.LoginAsync(logindDto);
-        string refreshToken = await authService.GenerateRefreshToken(User.Id());
+        string refreshToken = await jwtService.GenerateRefreshToken(User.Id());
 
         return Ok(new TokenResponse() { AccessToken = jwtToken, RefreshToken = refreshToken });
     }
@@ -54,7 +56,7 @@ public class AuthController : ControllerBase
     [ProducesResponseType(404)]
     public async Task<IActionResult> Refresh([FromBody] string refreshToken)
     {
-        var newAccessToken = await authService.GenerateAccessTokenFromRefreshToken(refreshToken);
+        var newAccessToken = await jwtService.GenerateAccessTokenFromRefreshToken(refreshToken);
 
         var response = new TokenResponse
         {

--- a/WarehouseManagement.Api/Controllers/AuthController.cs
+++ b/WarehouseManagement.Api/Controllers/AuthController.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Core.DTOs.Auth;
+
+namespace WarehouseManagement.Api.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class AuthController : ControllerBase
+{
+    private readonly IAuthService authService;
+
+    public AuthController(IAuthService authService)
+    {
+        this.authService = authService;
+    }
+
+    [HttpPost("login")]
+    [ProducesResponseType(200, Type = typeof(string))]
+    [ProducesResponseType(500)]
+    public async Task<IActionResult> Login([FromBody] LoginDto logindDto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        string jwtToken = await authService.LoginAsync(logindDto);
+
+        return Ok(jwtToken);
+    }
+
+    [HttpPost("register")]
+    [ProducesResponseType(200, Type = typeof(string))]
+    [ProducesResponseType(500)]
+    public async Task<IActionResult> Register([FromBody] RegisterDto registerDto)
+    {
+        if (!ModelState.IsValid)
+        {
+            return BadRequest(ModelState);
+        }
+
+        string jwtToken = await authService.RegisterAsync(registerDto);
+
+        return Ok(jwtToken);
+    }
+}

--- a/WarehouseManagement.Api/Controllers/DeliveryController.cs
+++ b/WarehouseManagement.Api/Controllers/DeliveryController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using WarehouseManagement.Common.MessageConstants.Keys;
 using WarehouseManagement.Core.Contracts;
@@ -41,6 +42,7 @@ public class DeliveryController : ControllerBase
 
     [HttpGet("all")]
     [ProducesResponseType(200, Type = typeof(PageDto<DeliveryDto>))]
+    [ProducesResponseType(401)]
     public async Task<IActionResult> GetDeliveries(
         [FromQuery] PaginationParameters paginationParams
     )

--- a/WarehouseManagement.Api/Controllers/DifferenceTypeController.cs
+++ b/WarehouseManagement.Api/Controllers/DifferenceTypeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using System.Security.Claims;
 using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs.DifferenceType;
@@ -6,6 +7,7 @@ using static WarehouseManagement.Common.MessageConstants.Keys.DifferenceTypeMess
 
 namespace WarehouseManagement.Api.Controllers;
 
+[Authorize]
 [Route("api/[controller]")]
 [ApiController]
 public class DifferenceTypeController : ControllerBase

--- a/WarehouseManagement.Api/Extensions/ServiceCollectionExtension.cs
+++ b/WarehouseManagement.Api/Extensions/ServiceCollectionExtension.cs
@@ -6,6 +6,7 @@ using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.Services;
 using WarehouseManagement.Infrastructure.Data;
 using WarehouseManagement.Infrastructure.Data.Common;
+using WarehouseManagement.Infrastructure.Data.Models;
 
 namespace WarehouseManagement.Api.Extensions
 {
@@ -22,6 +23,7 @@ namespace WarehouseManagement.Api.Extensions
             services.AddScoped<IDeliveryService, DeliveryService>();
             services.AddScoped<IDifferenceTypeService, DifferenceTypeService>();
             services.AddScoped<IDifferenceService, DifferenceService>();
+            services.AddScoped<IAuthService, AuthService>();
             return services;
         }
 
@@ -49,7 +51,7 @@ namespace WarehouseManagement.Api.Extensions
             //Here is Identity Configuration
 
             services
-                .AddDefaultIdentity<IdentityUser>(options =>
+                .AddDefaultIdentity<ApplicationUser>(options =>
                 {
                     options.SignIn.RequireConfirmedAccount = false;
                     options.Password.RequireNonAlphanumeric = false;
@@ -59,7 +61,7 @@ namespace WarehouseManagement.Api.Extensions
                     options.Password.RequiredLength = 4;
                     options.User.RequireUniqueEmail = true;
                 })
-                .AddRoles<IdentityRole>()
+                .AddRoles<IdentityRole<Guid>>()
                 .AddEntityFrameworkStores<WarehouseManagementDbContext>();
 
             return services;

--- a/WarehouseManagement.Api/Extensions/ServiceCollectionExtension.cs
+++ b/WarehouseManagement.Api/Extensions/ServiceCollectionExtension.cs
@@ -23,6 +23,7 @@ namespace WarehouseManagement.Api.Extensions
             services.AddScoped<IDeliveryService, DeliveryService>();
             services.AddScoped<IDifferenceTypeService, DifferenceTypeService>();
             services.AddScoped<IDifferenceService, DifferenceService>();
+            services.AddScoped<IJwtService, JwtService>();
             services.AddScoped<IAuthService, AuthService>();
             return services;
         }

--- a/WarehouseManagement.Api/Program.cs
+++ b/WarehouseManagement.Api/Program.cs
@@ -1,9 +1,10 @@
-using Microsoft.Data.SqlClient;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
 using WarehouseManagement.Api.Extensions;
 using WarehouseManagement.Api.Middlewares;
 using WarehouseManagement.Infrastructure.Data;
-
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -21,6 +22,24 @@ builder.Services.AddCors(options =>
 builder.Services.AddApplicationDbContext(builder.Configuration);
 builder.Services.AddApplicationIdentity(builder.Configuration);
 builder.Services.AddApplicationService();
+
+var jwtIssuer = builder.Configuration.GetSection("Jwt:Issuer").Get<string>();
+var jwtKey = builder.Configuration.GetSection("Jwt:Key").Get<string>();
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+ .AddJwtBearer(options =>
+ {
+     options.TokenValidationParameters = new TokenValidationParameters
+     {
+         ValidateIssuer = true,
+         ValidateAudience = true,
+         ValidateLifetime = true,
+         ValidateIssuerSigningKey = true,
+         ValidIssuer = jwtIssuer,
+         ValidAudience = jwtIssuer,
+         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey!))
+     };
+ });
 
 builder.Services.AddControllers();
 builder.Services.AddDbContext<WarehouseManagementDbContext>(options => 

--- a/WarehouseManagement.Api/Program.cs
+++ b/WarehouseManagement.Api/Program.cs
@@ -34,7 +34,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
          ValidateIssuer = true,
          ValidateAudience = true,
          ValidateLifetime = true,
-         ValidateIssuerSigningKey = true
+         ValidateIssuerSigningKey = true,
+         ClockSkew = TimeSpan.Zero
      };
  });
 

--- a/WarehouseManagement.Api/Program.cs
+++ b/WarehouseManagement.Api/Program.cs
@@ -23,23 +23,22 @@ builder.Services.AddApplicationDbContext(builder.Configuration);
 builder.Services.AddApplicationIdentity(builder.Configuration);
 builder.Services.AddApplicationService();
 
-var jwtIssuer = builder.Configuration.GetSection("Jwt:Issuer").Get<string>();
-var jwtKey = builder.Configuration.GetSection("Jwt:Key").Get<string>();
-
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
  .AddJwtBearer(options =>
  {
      options.TokenValidationParameters = new TokenValidationParameters
      {
+         ValidIssuer = builder.Configuration["Jwt:Issuer"],
+         ValidAudience = builder.Configuration["Jwt:Audience"],
+         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!)),
          ValidateIssuer = true,
          ValidateAudience = true,
          ValidateLifetime = true,
-         ValidateIssuerSigningKey = true,
-         ValidIssuer = jwtIssuer,
-         ValidAudience = jwtIssuer,
-         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey!))
+         ValidateIssuerSigningKey = true
      };
  });
+
+builder.Services.AddAuthorization();
 
 builder.Services.AddControllers();
 builder.Services.AddDbContext<WarehouseManagementDbContext>(options => 

--- a/WarehouseManagement.Api/WarehouseManagement.Api.csproj
+++ b/WarehouseManagement.Api/WarehouseManagement.Api.csproj
@@ -8,12 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WarehouseManagement.Api/appsettings.Development.json
+++ b/WarehouseManagement.Api/appsettings.Development.json
@@ -8,5 +8,11 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH",
+    "Issuer": "https://localhost:7226",
+    "Audience": "https://localhost:7226",
+    "Secret": "s3cR3tK3y660!#@_VerySecureAndLongEnoughToBeSafe"
+  }
 }

--- a/WarehouseManagement.Api/appsettings.json
+++ b/WarehouseManagement.Api/appsettings.json
@@ -8,5 +8,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH",
+    "Issuer": ""
+  }
 }

--- a/WarehouseManagement.Api/appsettings.json
+++ b/WarehouseManagement.Api/appsettings.json
@@ -11,8 +11,8 @@
   "AllowedHosts": "*",
   "Jwt": {
     "Key": "u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH",
-    "Issuer": "https://localhost:7226",
-    "Audience": "https://localhost:7226",
+    "Issuer": "http://leads-academy-intercars.com",
+    "Audience": "http://leads-academy-intercars.com",
     "Secret": "s3cR3tK3y660!#@_VerySecureAndLongEnoughToBeSafe"
   }
 }

--- a/WarehouseManagement.Api/appsettings.json
+++ b/WarehouseManagement.Api/appsettings.json
@@ -11,6 +11,7 @@
   "AllowedHosts": "*",
   "Jwt": {
     "Key": "u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH",
-    "Issuer": ""
+    "Issuer": "",
+    "Secret": "s3cR3tK3y660!#@_VerySecureAndLongEnoughToBeSafe"
   }
 }

--- a/WarehouseManagement.Api/appsettings.json
+++ b/WarehouseManagement.Api/appsettings.json
@@ -11,7 +11,8 @@
   "AllowedHosts": "*",
   "Jwt": {
     "Key": "u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH",
-    "Issuer": "",
+    "Issuer": "https://localhost:7226",
+    "Audience": "https://localhost:7226",
     "Secret": "s3cR3tK3y660!#@_VerySecureAndLongEnoughToBeSafe"
   }
 }

--- a/WarehouseManagement.Common/MessageConstants/Keys/AuthMassegeKeys.cs
+++ b/WarehouseManagement.Common/MessageConstants/Keys/AuthMassegeKeys.cs
@@ -1,0 +1,10 @@
+﻿namespace WarehouseManagement.Common.MessageConstants.Keys;
+
+public static class AuthMassegeKeys
+{
+    public const string UserRegisteredSuccessfully = "UserRegisteredSuccessfully";
+    public const string UserSignedOutSuccessfully = "UserSignedOutSuccessfully";
+    public const string AccessTokenHasExpired = "AccessTokenHasExpired";
+    public const string RefreshTokenHasExpired = "RefreshTokenHasExpired";
+    public const string RefreshTokenNotFound = "RefreshTokenNotFound";
+}

--- a/WarehouseManagement.Core/Contracts/IAuthService.cs
+++ b/WarehouseManagement.Core/Contracts/IAuthService.cs
@@ -1,10 +1,12 @@
-﻿namespace WarehouseManagement.Core.Contracts;
+﻿using WarehouseManagement.Core.DTOs.Auth;
+
+namespace WarehouseManagement.Core.Contracts;
 
 public interface IAuthService
 {
     string GenerateJwtToken(string userId, string username, string email);
 
-    Task RegisterAsync();
+    Task<string> RegisterAsync(RegisterDto registerDto);
 
-    Task LoginAsync();
+    Task<string> LoginAsync(LoginDto loginDto);
 }

--- a/WarehouseManagement.Core/Contracts/IAuthService.cs
+++ b/WarehouseManagement.Core/Contracts/IAuthService.cs
@@ -1,0 +1,10 @@
+﻿namespace WarehouseManagement.Core.Contracts;
+
+public interface IAuthService
+{
+    string GenerateJwtToken(string userId, string username, string email);
+
+    Task RegisterAsync();
+
+    Task LoginAsync();
+}

--- a/WarehouseManagement.Core/Contracts/IAuthService.cs
+++ b/WarehouseManagement.Core/Contracts/IAuthService.cs
@@ -6,7 +6,13 @@ public interface IAuthService
 {
     string GenerateJwtToken(string userId, string username, string email);
 
-    Task<string> RegisterAsync(RegisterDto registerDto);
+    Task<string> GenerateRefreshToken(string userId);
+
+    Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken);
+
+    Task RegisterAsync(RegisterDto registerDto);
 
     Task<string> LoginAsync(LoginDto loginDto);
+
+    Task LogoutAsync(string userId);
 }

--- a/WarehouseManagement.Core/Contracts/IAuthService.cs
+++ b/WarehouseManagement.Core/Contracts/IAuthService.cs
@@ -4,12 +4,6 @@ namespace WarehouseManagement.Core.Contracts;
 
 public interface IAuthService
 {
-    string GenerateJwtToken(string userId, string username, string email);
-
-    Task<string> GenerateRefreshToken(string userId);
-
-    Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken);
-
     Task RegisterAsync(RegisterDto registerDto);
 
     Task<string> LoginAsync(LoginDto loginDto);

--- a/WarehouseManagement.Core/Contracts/IJwtService.cs
+++ b/WarehouseManagement.Core/Contracts/IJwtService.cs
@@ -1,0 +1,14 @@
+﻿using WarehouseManagement.Infrastructure.Data.Models;
+
+namespace WarehouseManagement.Core.Contracts;
+
+public interface IJwtService
+{
+    string ComposeAccessToken(string userId, string username, string email);
+
+    Task<string> GenerateRefreshToken(string userId);
+
+    Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken);
+
+    Task RevokeOldRefreshTokens(ApplicationUser user);
+}

--- a/WarehouseManagement.Core/DTOs/Auth/LoginDto.cs
+++ b/WarehouseManagement.Core/DTOs/Auth/LoginDto.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace WarehouseManagement.Core.DTOs.Auth;
+
+public class LoginDto
+{
+    [StringLength(100, MinimumLength = 1)]
+    public string Username { get; set; } = null!;
+
+    [StringLength(250, MinimumLength = 5)]
+    public string Password { get; set; } = null!;
+}

--- a/WarehouseManagement.Core/DTOs/Auth/RegisterDto.cs
+++ b/WarehouseManagement.Core/DTOs/Auth/RegisterDto.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace WarehouseManagement.Core.DTOs.Auth;
+
+public class RegisterDto
+{
+    [StringLength(100, MinimumLength = 1)]
+    public string Username { get; set; } = null!;
+
+    [StringLength(150, MinimumLength = 1)]
+    public string Email { get; set; } = null!;
+
+    [StringLength(250, MinimumLength = 5)]
+    public string Password { get; set; } = null!;
+}

--- a/WarehouseManagement.Core/DTOs/Auth/TokenResponse.cs
+++ b/WarehouseManagement.Core/DTOs/Auth/TokenResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace WarehouseManagement.Core.DTOs.Auth;
+
+public class TokenResponse
+{
+    public string AccessToken { get; set; } = string.Empty;
+
+    public string RefreshToken { get; set; } = string.Empty;
+}

--- a/WarehouseManagement.Core/Services/AuthService.cs
+++ b/WarehouseManagement.Core/Services/AuthService.cs
@@ -1,99 +1,24 @@
 ﻿using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs.Auth;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
-using static WarehouseManagement.Common.MessageConstants.Keys.AuthMassegeKeys;
 
 public class AuthService : IAuthService
 {
-    private readonly IRepository repository;
     private readonly SignInManager<ApplicationUser> signInManager;
     private readonly UserManager<ApplicationUser> userManager;
-    private readonly IConfiguration configuration;
 
-    public AuthService(IRepository repository, SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager, IConfiguration configuration)
+    private readonly IRepository repository;
+    private readonly IJwtService jwtService;
+
+    public AuthService(IRepository repository, SignInManager<ApplicationUser> signInManager, UserManager<ApplicationUser> userManager, IJwtService jwtService)
     {
         this.repository = repository;
         this.signInManager = signInManager;
         this.userManager = userManager;
-        this.configuration = configuration;
-    }
-
-    public string GenerateJwtToken(string userId, string username, string email)
-    {
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
-
-        var token = ComposeAccessToken(userId, userId, email);
-
-        return token;
-    }
-
-    public async Task<string> GenerateRefreshToken(string userId)
-    {
-        var refreshToken = new RefreshToken()
-        {
-            Token = Guid.NewGuid().ToString().Replace("-", ""),
-            ExpirationDate = DateTime.UtcNow.AddDays(7),
-            UserId = Guid.Parse(userId)
-        };
-
-        await repository.AddAsync(refreshToken);
-        await repository.SaveChangesAsync();
-
-        return refreshToken.Token;
-    }
-
-    public async Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken)
-    {
-        var refreshTokenEntity = await repository
-            .All<RefreshToken>()
-            .Include(t => t.User)
-            .FirstOrDefaultAsync(t => t.Token == refreshToken);
-
-        if (refreshTokenEntity == null)
-        {
-            throw new KeyNotFoundException(RefreshTokenNotFound);
-        }
-
-        if (refreshTokenEntity.ExpirationDate < DateTime.UtcNow)
-        {
-            throw new InvalidOperationException(RefreshTokenHasExpired);
-        }
-
-        var token = ComposeAccessToken(refreshTokenEntity.UserId.ToString(), refreshTokenEntity.User.UserName!, refreshTokenEntity.User.Email!);
-
-        return token;
-    }
-
-    private string ComposeAccessToken(string userId, string username, string email)
-    {
-        var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
-
-        var tokenDescriptor = new SecurityTokenDescriptor
-        {
-            Subject = new ClaimsIdentity(new[]
-            {
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.Email, email)
-            }),
-            Issuer = configuration["Jwt:Issuer"],
-            Audience = configuration["Jwt:Audience"],
-            Expires = DateTime.UtcNow.AddMinutes(10),
-            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
-        };
-
-        var token = tokenHandler.CreateToken(tokenDescriptor);
-        return tokenHandler.WriteToken(token);
+        this.jwtService = jwtService;
     }
 
     public async Task RegisterAsync(RegisterDto registerDto)
@@ -124,29 +49,15 @@ public class AuthService : IAuthService
             throw new ArgumentException("Email or password is incorrect.");
         }
 
-        var result = await signInManager.PasswordSignInAsync(user.UserName!, loginDto.Password, true, false);
+        var result = await signInManager.PasswordSignInAsync(user.UserName!, loginDto.Password, false, false);
 
         if (!result.Succeeded)
         {
             throw new Exception("Invalid login attempt.");
         }
 
-        await RevokeOldRefreshTokens(user);
-        return GenerateJwtToken(user!.Id.ToString(), user.UserName!, user.Email!);
-    }
-
-    private async Task RevokeOldRefreshTokens(ApplicationUser user)
-    {
-        foreach (var refreshToken in user.RefreshTokens)
-        {
-            // Maybe directly delete them from the DB
-            if (!refreshToken.IsRevoked)
-            {
-                refreshToken.IsRevoked = true;
-            }
-        }
-
-        await repository.SaveChangesAsync();
+        await jwtService.RevokeOldRefreshTokens(user);
+        return jwtService.ComposeAccessToken(user!.Id.ToString(), user.UserName!, user.Email!);
     }
 
     public async Task LogoutAsync(string userId)

--- a/WarehouseManagement.Core/Services/AuthService.cs
+++ b/WarehouseManagement.Core/Services/AuthService.cs
@@ -39,6 +39,8 @@ public class AuthService : IAuthService
                 new Claim(ClaimTypes.Name, username),
                 new Claim(ClaimTypes.Email, email)
             }),
+            Issuer = "https://localhost:7226",
+            Audience = "https://localhost:7226",
             Expires = DateTime.UtcNow.AddMinutes(10),
             SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
         };

--- a/WarehouseManagement.Core/Services/AuthService.cs
+++ b/WarehouseManagement.Core/Services/AuthService.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Infrastructure.Data.Common;
+using WarehouseManagement.Infrastructure.Data.Models;
+
+namespace WarehouseManagement.Core.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly IRepository repository;
+
+    private readonly SignInManager<ApplicationUser> signInManager;
+    private readonly UserManager<ApplicationUser> userManager;
+
+    public AuthService(
+        IRepository repository, 
+        SignInManager<ApplicationUser> signInManager, 
+        UserManager<ApplicationUser> userManager)
+    {
+        this.repository = repository;
+        this.signInManager = signInManager;
+        this.userManager = userManager;
+    }
+
+    public string GenerateJwtToken(string userId, string username, string email)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes("yourSecretKey");
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim("id", userId), new Claim("username", username), new Claim("email", email) }),
+            Expires = DateTime.UtcNow.AddDays(7),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    public Task RegisterAsync()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Task LoginAsync()
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/WarehouseManagement.Core/Services/AuthService.cs
+++ b/WarehouseManagement.Core/Services/AuthService.cs
@@ -29,7 +29,7 @@ public class AuthService : IAuthService
     public string GenerateJwtToken(string userId, string username, string email)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Secret"]!);
+        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
 
         var tokenDescriptor = new SecurityTokenDescriptor
         {
@@ -67,7 +67,7 @@ public class AuthService : IAuthService
     public async Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Secret"]!);
+        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
 
         var refreshTokenEntity = await repository
             .All<RefreshToken>()

--- a/WarehouseManagement.Core/Services/AuthService.cs
+++ b/WarehouseManagement.Core/Services/AuthService.cs
@@ -1,9 +1,12 @@
-﻿using Microsoft.AspNetCore.Identity;
+﻿using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Core.DTOs.Auth;
 using WarehouseManagement.Infrastructure.Data.Common;
 using WarehouseManagement.Infrastructure.Data.Models;
 
@@ -29,7 +32,7 @@ public class AuthService : IAuthService
     public string GenerateJwtToken(string userId, string username, string email)
     {
         var tokenHandler = new JwtSecurityTokenHandler();
-        var key = Encoding.ASCII.GetBytes("yourSecretKey");
+        var key = Encoding.ASCII.GetBytes("u2vXj3t8P9pL4cQ7rS6sW1e0bG5zK7aD2nS3yU8oJ9lF6dA9gH");
 
         var tokenDescriptor = new SecurityTokenDescriptor
         {
@@ -42,13 +45,50 @@ public class AuthService : IAuthService
         return tokenHandler.WriteToken(token);
     }
 
-    public Task RegisterAsync()
+    public async Task<string> RegisterAsync(RegisterDto registerDto)
     {
-        throw new NotImplementedException();
+        var user = new ApplicationUser
+        {
+            UserName = registerDto.Username,
+            Email = registerDto.Email,
+            PasswordHash = HashPassword(registerDto.Password)
+        };
+
+        var result = await userManager.CreateAsync(user);
+
+        if (!result.Succeeded)
+        {
+            throw new Exception(string.Join(", ", result.Errors.Select(e => e.Description)));
+        }
+
+        return GenerateJwtToken(user.Id.ToString(), user.UserName, user.Email);
     }
 
-    public Task LoginAsync()
+    public async Task<string> LoginAsync(LoginDto loginDto)
     {
-        throw new NotImplementedException();
+        var result = await signInManager.PasswordSignInAsync(loginDto.Username, loginDto.Password, false, lockoutOnFailure: false);
+
+        if (!result.Succeeded)
+        {
+            throw new Exception("Invalid login attempt.");
+        }
+
+        var user = await userManager.FindByNameAsync(loginDto.Username);
+
+        return GenerateJwtToken(user!.Id.ToString(), user.UserName!, user.Email!);
+    }
+
+    private string HashPassword(string password)
+    {
+        var salt = RandomNumberGenerator.GetBytes(128 / 8);
+
+        var hashed = Convert.ToBase64String(KeyDerivation.Pbkdf2(
+            password,
+            salt,
+            KeyDerivationPrf.HMACSHA256,
+            100000,
+            256 / 8));
+
+        return hashed;
     }
 }

--- a/WarehouseManagement.Core/Services/JwtService.cs
+++ b/WarehouseManagement.Core/Services/JwtService.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using WarehouseManagement.Core.Contracts;
+using WarehouseManagement.Infrastructure.Data.Common;
+using WarehouseManagement.Infrastructure.Data.Models;
+using static WarehouseManagement.Common.MessageConstants.Keys.AuthMassegeKeys;
+
+namespace WarehouseManagement.Core.Services;
+
+public class JwtService : IJwtService
+{
+    private readonly IRepository repository;
+    private readonly IConfiguration configuration;
+
+    public JwtService(IRepository repository, IConfiguration configuration)
+    {
+        this.repository = repository;
+        this.configuration = configuration;
+    }
+
+    public string ComposeAccessToken(string userId, string username, string email)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var key = Encoding.ASCII.GetBytes(configuration["Jwt:Key"]!);
+
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId),
+                new Claim(ClaimTypes.Name, username),
+                new Claim(ClaimTypes.Email, email)
+            }),
+            Issuer = configuration["Jwt:Issuer"],
+            Audience = configuration["Jwt:Audience"],
+            Expires = DateTime.UtcNow.AddMinutes(10),
+            SigningCredentials = new SigningCredentials(new SymmetricSecurityKey(key), SecurityAlgorithms.HmacSha256Signature)
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    public async Task<string> GenerateAccessTokenFromRefreshToken(string refreshToken)
+    {
+        var refreshTokenEntity = await repository
+            .All<RefreshToken>()
+            .Include(t => t.User)
+            .FirstOrDefaultAsync(t => t.Token == refreshToken);
+
+        if (refreshTokenEntity == null)
+        {
+            throw new KeyNotFoundException(RefreshTokenNotFound);
+        }
+
+        if (refreshTokenEntity.ExpirationDate < DateTime.UtcNow)
+        {
+            throw new InvalidOperationException(RefreshTokenHasExpired);
+        }
+
+        var token = ComposeAccessToken(refreshTokenEntity.UserId.ToString(), refreshTokenEntity.User.UserName!, refreshTokenEntity.User.Email!);
+
+        return token;
+    }
+
+    public async Task<string> GenerateRefreshToken(string userId)
+    {
+        var refreshToken = new RefreshToken()
+        {
+            Token = Guid.NewGuid().ToString().Replace("-", ""),
+            ExpirationDate = DateTime.UtcNow.AddDays(7),
+            UserId = Guid.Parse(userId)
+        };
+
+        await repository.AddAsync(refreshToken);
+        await repository.SaveChangesAsync();
+
+        return refreshToken.Token;
+    }
+
+    public async Task RevokeOldRefreshTokens(ApplicationUser user)
+    {
+        foreach (var refreshToken in user.RefreshTokens)
+        {
+            // Maybe directly delete them from the DB
+            if (!refreshToken.IsRevoked)
+            {
+                refreshToken.IsRevoked = true;
+            }
+        }
+
+        await repository.SaveChangesAsync();
+    }
+}

--- a/WarehouseManagement.Core/WarehouseManagement.Core.csproj
+++ b/WarehouseManagement.Core/WarehouseManagement.Core.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\WarehouseManagement.Infrastructure\WarehouseManagement.Infrastructure.csproj" />
   </ItemGroup>
 

--- a/WarehouseManagement.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
+++ b/WarehouseManagement.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using WarehouseManagement.Infrastructure.Data.Models;
+
+namespace WarehouseManagement.Infrastructure.Data.Configurations;
+
+public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
+{
+    public void Configure(EntityTypeBuilder<RefreshToken> builder)
+    {
+        builder.HasQueryFilter(t => !t.IsRevoked);
+    }
+}

--- a/WarehouseManagement.Infrastructure/Data/Models/ApplicationUser.cs
+++ b/WarehouseManagement.Infrastructure/Data/Models/ApplicationUser.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Identity;
+
+namespace WarehouseManagement.Infrastructure.Data.Models;
+
+public class ApplicationUser : IdentityUser<Guid>
+{
+    public ApplicationUser()
+    {
+        this.Id = Guid.NewGuid();
+    }
+}

--- a/WarehouseManagement.Infrastructure/Data/Models/ApplicationUser.cs
+++ b/WarehouseManagement.Infrastructure/Data/Models/ApplicationUser.cs
@@ -8,4 +8,6 @@ public class ApplicationUser : IdentityUser<Guid>
     {
         this.Id = Guid.NewGuid();
     }
+
+    public ICollection<RefreshToken> RefreshTokens { get; set; } = new HashSet<RefreshToken>();
 }

--- a/WarehouseManagement.Infrastructure/Data/Models/RefreshToken.cs
+++ b/WarehouseManagement.Infrastructure/Data/Models/RefreshToken.cs
@@ -1,0 +1,16 @@
+﻿namespace WarehouseManagement.Infrastructure.Data.Models;
+
+public class RefreshToken
+{
+    public int Id { get; set; }
+
+    public string Token { get; set; } = string.Empty;
+
+    public DateTime ExpirationDate { get; set; }
+
+    public bool IsRevoked { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public ApplicationUser User { get; set; } = null!;
+}

--- a/WarehouseManagement.Infrastructure/Data/WarehouseManagementDbContext.cs
+++ b/WarehouseManagement.Infrastructure/Data/WarehouseManagementDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -7,7 +8,7 @@ using WarehouseManagement.Infrastructure.Data.Models;
 
 namespace WarehouseManagement.Infrastructure.Data
 {
-    public class WarehouseManagementDbContext : IdentityDbContext
+    public class WarehouseManagementDbContext : IdentityDbContext<ApplicationUser, IdentityRole<Guid>, Guid>
     {
         private readonly IUserService userService;
 

--- a/WarehouseManagement.Infrastructure/Data/WarehouseManagementDbContext.cs
+++ b/WarehouseManagement.Infrastructure/Data/WarehouseManagementDbContext.cs
@@ -28,6 +28,7 @@ namespace WarehouseManagement.Infrastructure.Data
         public DbSet<Zone> Zones { get; set; } = null!;
         public DbSet<DifferenceType> DifferenceTypes { get; set; } = null!;
         public DbSet<Difference> Differences { get; set; } = null!;
+        public DbSet<RefreshToken> RefreshTokens { get; set; } = null!;
         public DbSet<DeliveryMarker> DeliveriesMarkers { get; set; } = null!;
         public DbSet<VendorMarker> VendorsMarkers { get; set; } = null!;
         public DbSet<VendorZone> VendorsZones { get; set; } = null!;

--- a/WarehouseManagement.Infrastructure/Migrations/20240727133148_Initial.Designer.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/20240727133148_Initial.Designer.cs
@@ -12,7 +12,7 @@ using WarehouseManagement.Infrastructure.Data;
 namespace WarehouseManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(WarehouseManagementDbContext))]
-    [Migration("20240723094002_Initial")]
+    [Migration("20240727133148_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -25,10 +25,11 @@ namespace WarehouseManagement.Infrastructure.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
@@ -52,7 +53,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetRoles", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -66,9 +67,8 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("RoleId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.HasKey("Id");
 
@@ -77,10 +77,94 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetRoleClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserClaims", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("ProviderKey")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("ProviderDisplayName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserLogins", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetUserRoles", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("Value")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("AspNetUserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<int>("AccessFailedCount")
                         .HasColumnType("int");
@@ -142,91 +226,6 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("AspNetUserClaims", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-                {
-                    b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("ProviderKey")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("LoginProvider", "ProviderKey");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("AspNetUserLogins", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("RoleId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("UserId", "RoleId");
-
-                    b.HasIndex("RoleId");
-
-                    b.ToTable("AspNetUserRoles", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("Value")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("UserId", "LoginProvider", "Name");
-
-                    b.ToTable("AspNetUserTokens", (string)null);
-                });
-
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Delivery", b =>
                 {
                     b.Property<int>("Id")
@@ -245,7 +244,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 364, DateTimeKind.Utc).AddTicks(152));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -355,7 +354,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(717));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -421,7 +420,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(3317));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -506,7 +505,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(6415));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -571,7 +570,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(8671));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -615,7 +614,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 366, DateTimeKind.Utc).AddTicks(418));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -693,7 +692,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 367, DateTimeKind.Utc).AddTicks(4580));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -744,51 +743,51 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("ZonesMarkers");
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/WarehouseManagement.Infrastructure/Migrations/20240727133148_Initial.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/20240727133148_Initial.cs
@@ -15,7 +15,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "AspNetRoles",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
                     NormalizedName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
                     ConcurrencyStamp = table.Column<string>(type: "nvarchar(max)", nullable: true)
@@ -29,7 +29,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "AspNetUsers",
                 columns: table => new
                 {
-                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     UserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
                     NormalizedUserName = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
                     Email = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: true),
@@ -57,7 +57,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(3317)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -95,7 +95,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(8671)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -116,7 +116,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     SystemNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 366, DateTimeKind.Utc).AddTicks(418)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -137,7 +137,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     IsFinal = table.Column<bool>(type: "bit", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 367, DateTimeKind.Utc).AddTicks(4580)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -156,7 +156,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    RoleId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
                 },
@@ -177,7 +177,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 {
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     ClaimType = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     ClaimValue = table.Column<string>(type: "nvarchar(max)", nullable: true)
                 },
@@ -199,7 +199,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
                     ProviderKey = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
                     ProviderDisplayName = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -216,8 +216,8 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "AspNetUserRoles",
                 columns: table => new
                 {
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    RoleId = table.Column<string>(type: "nvarchar(450)", nullable: false)
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    RoleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -240,7 +240,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "AspNetUserTokens",
                 columns: table => new
                 {
-                    UserId = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     LoginProvider = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
                     Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
                     Value = table.Column<string>(type: "nvarchar(max)", nullable: true)
@@ -276,7 +276,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     StartedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     FinishedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     VendorId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 364, DateTimeKind.Utc).AddTicks(152)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -407,7 +407,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     TypeId = table.Column<int>(type: "int", nullable: false),
                     DeliveryId = table.Column<int>(type: "int", nullable: false),
                     ZoneId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(717)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -451,7 +451,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     FinishedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     ZoneId = table.Column<int>(type: "int", nullable: false),
                     DeliveryId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(6415)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),

--- a/WarehouseManagement.Infrastructure/Migrations/20240802081626_Initial.Designer.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/20240802081626_Initial.Designer.cs
@@ -12,7 +12,7 @@ using WarehouseManagement.Infrastructure.Data;
 namespace WarehouseManagement.Infrastructure.Migrations
 {
     [DbContext(typeof(WarehouseManagementDbContext))]
-    [Migration("20240727133148_Initial")]
+    [Migration("20240802081626_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -244,7 +244,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 809, DateTimeKind.Utc).AddTicks(9375));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -354,7 +354,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(7301));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -420,7 +420,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(9196));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -505,7 +505,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(2597));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -570,7 +570,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(4344));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -603,6 +603,34 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("Markers");
                 });
 
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.RefreshToken", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("datetime2");
+
+                    b.Property<bool>("IsRevoked")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Token")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("RefreshTokens");
+                });
+
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Vendor", b =>
                 {
                     b.Property<int>("Id")
@@ -614,7 +642,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(7197));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -692,7 +720,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 812, DateTimeKind.Utc).AddTicks(9136));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -870,6 +898,17 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Navigation("Zone");
                 });
 
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.RefreshToken", b =>
+                {
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", "User")
+                        .WithMany("RefreshTokens")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.VendorMarker", b =>
                 {
                     b.HasOne("WarehouseManagement.Infrastructure.Data.Models.Marker", "Marker")
@@ -925,6 +964,11 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Navigation("Marker");
 
                     b.Navigation("Zone");
+                });
+
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", b =>
+                {
+                    b.Navigation("RefreshTokens");
                 });
 
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Delivery", b =>

--- a/WarehouseManagement.Infrastructure/Migrations/20240802081626_Initial.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/20240802081626_Initial.cs
@@ -57,7 +57,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(9196)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -95,7 +95,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(4344)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -116,7 +116,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     SystemNumber = table.Column<string>(type: "nvarchar(max)", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(7197)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -137,7 +137,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Name = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     IsFinal = table.Column<bool>(type: "bit", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 812, DateTimeKind.Utc).AddTicks(9136)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -257,6 +257,28 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "RefreshTokens",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Token = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ExpirationDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsRevoked = table.Column<bool>(type: "bit", nullable: false),
+                    UserId = table.Column<Guid>(type: "uniqueidentifier", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_RefreshTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_RefreshTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Deliveries",
                 columns: table => new
                 {
@@ -276,7 +298,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     StartedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     FinishedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     VendorId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 809, DateTimeKind.Utc).AddTicks(9375)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -407,7 +429,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     TypeId = table.Column<int>(type: "int", nullable: false),
                     DeliveryId = table.Column<int>(type: "int", nullable: false),
                     ZoneId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(7301)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -451,7 +473,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     FinishedProcessing = table.Column<DateTime>(type: "datetime2", nullable: true),
                     ZoneId = table.Column<int>(type: "int", nullable: false),
                     DeliveryId = table.Column<int>(type: "int", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350)),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false, defaultValue: new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(2597)),
                     CreatedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
                     LastModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
                     LastModifiedByUserId = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: true),
@@ -551,6 +573,11 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 column: "ZoneId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_RefreshTokens_UserId",
+                table: "RefreshTokens",
+                column: "UserId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_VendorsMarkers_VendorId",
                 table: "VendorsMarkers",
                 column: "VendorId");
@@ -597,6 +624,9 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "Entries");
 
             migrationBuilder.DropTable(
+                name: "RefreshTokens");
+
+            migrationBuilder.DropTable(
                 name: "VendorsMarkers");
 
             migrationBuilder.DropTable(
@@ -609,13 +639,13 @@ namespace WarehouseManagement.Infrastructure.Migrations
                 name: "AspNetRoles");
 
             migrationBuilder.DropTable(
-                name: "AspNetUsers");
-
-            migrationBuilder.DropTable(
                 name: "DifferenceTypes");
 
             migrationBuilder.DropTable(
                 name: "Deliveries");
+
+            migrationBuilder.DropTable(
+                name: "AspNetUsers");
 
             migrationBuilder.DropTable(
                 name: "Markers");

--- a/WarehouseManagement.Infrastructure/Migrations/WarehouseManagementDbContextModelSnapshot.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/WarehouseManagementDbContextModelSnapshot.cs
@@ -22,10 +22,11 @@ namespace WarehouseManagement.Infrastructure.Migrations
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
@@ -49,7 +50,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetRoles", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
@@ -63,9 +64,8 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<string>("ClaimValue")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<string>("RoleId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
 
                     b.HasKey("Id");
 
@@ -74,10 +74,94 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetRoleClaims", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUser", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.Property<string>("Id")
-                        .HasColumnType("nvarchar(450)");
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("ClaimType")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("ClaimValue")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserClaims", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
+                {
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("ProviderKey")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("ProviderDisplayName")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("AspNetUserLogins", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<Guid>("RoleId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("AspNetUserRoles", (string)null);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
+                {
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("LoginProvider")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("Name")
+                        .HasMaxLength(128)
+                        .HasColumnType("nvarchar(128)");
+
+                    b.Property<string>("Value")
+                        .HasColumnType("nvarchar(max)");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("AspNetUserTokens", (string)null);
+                });
+
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
 
                     b.Property<int>("AccessFailedCount")
                         .HasColumnType("int");
@@ -139,91 +223,6 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
-
-                    b.Property<string>("ClaimType")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("ClaimValue")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("AspNetUserClaims", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
-                {
-                    b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("ProviderKey")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("UserId")
-                        .IsRequired()
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("LoginProvider", "ProviderKey");
-
-                    b.HasIndex("UserId");
-
-                    b.ToTable("AspNetUserLogins", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("RoleId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.HasKey("UserId", "RoleId");
-
-                    b.HasIndex("RoleId");
-
-                    b.ToTable("AspNetUserRoles", (string)null);
-                });
-
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
-                {
-                    b.Property<string>("UserId")
-                        .HasColumnType("nvarchar(450)");
-
-                    b.Property<string>("LoginProvider")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("Name")
-                        .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
-
-                    b.Property<string>("Value")
-                        .HasColumnType("nvarchar(max)");
-
-                    b.HasKey("UserId", "LoginProvider", "Name");
-
-                    b.ToTable("AspNetUserTokens", (string)null);
-                });
-
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Delivery", b =>
                 {
                     b.Property<int>("Id")
@@ -242,7 +241,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 364, DateTimeKind.Utc).AddTicks(152));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -352,7 +351,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(717));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -418,7 +417,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(3317));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -503,7 +502,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(6415));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -568,7 +567,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 365, DateTimeKind.Utc).AddTicks(8671));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -612,7 +611,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 366, DateTimeKind.Utc).AddTicks(418));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -690,7 +689,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 23, 9, 39, 58, 367, DateTimeKind.Utc).AddTicks(4580));
+                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -741,51 +740,51 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("ZonesMarkers");
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole<System.Guid>", null)
                         .WithMany()
                         .HasForeignKey("RoleId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
                 });
 
-            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<System.Guid>", b =>
                 {
-                    b.HasOne("Microsoft.AspNetCore.Identity.IdentityUser", null)
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", null)
                         .WithMany()
                         .HasForeignKey("UserId")
                         .OnDelete(DeleteBehavior.Cascade)

--- a/WarehouseManagement.Infrastructure/Migrations/WarehouseManagementDbContextModelSnapshot.cs
+++ b/WarehouseManagement.Infrastructure/Migrations/WarehouseManagementDbContextModelSnapshot.cs
@@ -241,7 +241,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 590, DateTimeKind.Utc).AddTicks(5682));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 809, DateTimeKind.Utc).AddTicks(9375));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -351,7 +351,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(3418));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(7301));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -417,7 +417,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(5668));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 810, DateTimeKind.Utc).AddTicks(9196));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -502,7 +502,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 591, DateTimeKind.Utc).AddTicks(9350));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(2597));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -567,7 +567,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(1218));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(4344));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -600,6 +600,34 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.ToTable("Markers");
                 });
 
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.RefreshToken", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("int");
+
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
+
+                    b.Property<DateTime>("ExpirationDate")
+                        .HasColumnType("datetime2");
+
+                    b.Property<bool>("IsRevoked")
+                        .HasColumnType("bit");
+
+                    b.Property<string>("Token")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uniqueidentifier");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("RefreshTokens");
+                });
+
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Vendor", b =>
                 {
                     b.Property<int>("Id")
@@ -611,7 +639,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 592, DateTimeKind.Utc).AddTicks(2974));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 811, DateTimeKind.Utc).AddTicks(7197));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -689,7 +717,7 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .ValueGeneratedOnAdd()
                         .HasColumnType("datetime2")
-                        .HasDefaultValue(new DateTime(2024, 7, 27, 13, 31, 48, 594, DateTimeKind.Utc).AddTicks(1170));
+                        .HasDefaultValue(new DateTime(2024, 8, 2, 8, 16, 25, 812, DateTimeKind.Utc).AddTicks(9136));
 
                     b.Property<string>("CreatedByUserId")
                         .IsRequired()
@@ -867,6 +895,17 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Navigation("Zone");
                 });
 
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.RefreshToken", b =>
+                {
+                    b.HasOne("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", "User")
+                        .WithMany("RefreshTokens")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
+                });
+
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.VendorMarker", b =>
                 {
                     b.HasOne("WarehouseManagement.Infrastructure.Data.Models.Marker", "Marker")
@@ -922,6 +961,11 @@ namespace WarehouseManagement.Infrastructure.Migrations
                     b.Navigation("Marker");
 
                     b.Navigation("Zone");
+                });
+
+            modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.ApplicationUser", b =>
+                {
+                    b.Navigation("RefreshTokens");
                 });
 
             modelBuilder.Entity("WarehouseManagement.Infrastructure.Data.Models.Delivery", b =>


### PR DESCRIPTION
Added `SignIn`, `SignUp`, `SignOut` functionality. Generating `access` and `refresh` tokens upon successful login which contain `userId`, `email` and `username` as claims. Extending the `IdentityUser`. 