### PR TITLE
Make the delivery status to depend on the difference status

### DIFF
--- a/WarehouseManagement.Api/Controllers/DifferenceController.cs
+++ b/WarehouseManagement.Api/Controllers/DifferenceController.cs
@@ -65,8 +65,7 @@ public class DifferenceController : ControllerBase
 
         await differenceService.CreateAsync(model, User.Id());
 
-        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
-        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
+        //TODO maybe update the difference of the delivery here?
 
         return Ok(DifferenceAddedSuccessfully);
     }

--- a/WarehouseManagement.Api/Controllers/DifferenceController.cs
+++ b/WarehouseManagement.Api/Controllers/DifferenceController.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
-using System.Security.Claims;
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Mvc;
 using WarehouseManagement.Core.Contracts;
 using WarehouseManagement.Core.DTOs;
 using WarehouseManagement.Core.DTOs.Difference;
@@ -12,10 +12,15 @@ namespace WarehouseManagement.Api.Controllers;
 public class DifferenceController : ControllerBase
 {
     private readonly IDifferenceService differenceService;
+    private readonly IDeliveryService deliveryService;
 
-    public DifferenceController(IDifferenceService differenceService)
+    public DifferenceController(
+        IDifferenceService differenceService,
+        IDeliveryService deliveryService
+    )
     {
         this.differenceService = differenceService;
+        this.deliveryService = deliveryService;
     }
 
     [HttpGet("all")]
@@ -29,7 +34,9 @@ public class DifferenceController : ControllerBase
 
     [HttpGet("all-with-deleted")]
     [ProducesResponseType(200, Type = typeof(PageDto<DifferenceDto>))]
-    public async Task<IActionResult> AllWithDeleted([FromQuery] PaginationParameters paginationParams)
+    public async Task<IActionResult> AllWithDeleted(
+        [FromQuery] PaginationParameters paginationParams
+    )
     {
         var pageDto = await differenceService.GetAllWithDeletedAsync(paginationParams);
 
@@ -58,6 +65,9 @@ public class DifferenceController : ControllerBase
 
         await differenceService.CreateAsync(model, User.Id());
 
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
+
         return Ok(DifferenceAddedSuccessfully);
     }
 
@@ -82,6 +92,9 @@ public class DifferenceController : ControllerBase
     {
         await differenceService.DeleteAsync(id);
 
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
+
         return Ok(DifferenceDeletedSuccessfully);
     }
 
@@ -92,6 +105,9 @@ public class DifferenceController : ControllerBase
     public async Task<IActionResult> Restore(int id)
     {
         await differenceService.RestoreAsync(id);
+
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
 
         return Ok(DifferenceRestored);
     }
@@ -104,6 +120,9 @@ public class DifferenceController : ControllerBase
     {
         await differenceService.StartProcessing(id);
 
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
+
         return Ok(DifferenceSuccessfullyStartedProcessing);
     }
 
@@ -111,9 +130,15 @@ public class DifferenceController : ControllerBase
     [ProducesResponseType(200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(404)]
-    public async Task<IActionResult> FinishProcessing(int id, [FromBody] DifferenceAdminCommentDto adminCommentDto)
+    public async Task<IActionResult> FinishProcessing(
+        int id,
+        [FromBody] DifferenceAdminCommentDto adminCommentDto
+    )
     {
         await differenceService.FinishProcessing(id, adminCommentDto);
+
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
 
         return Ok(DifferenceSuccessfullyFinishedProcessing);
     }
@@ -122,9 +147,15 @@ public class DifferenceController : ControllerBase
     [ProducesResponseType(200)]
     [ProducesResponseType(400)]
     [ProducesResponseType(404)]
-    public async Task<IActionResult> NoDifferences(int id, [FromBody] DifferenceAdminCommentDto adminCommentDto)
+    public async Task<IActionResult> NoDifferences(
+        int id,
+        [FromBody] DifferenceAdminCommentDto adminCommentDto
+    )
     {
         await differenceService.NoDifferences(id, adminCommentDto);
+
+        var deliveryId = await differenceService.GetDeliveryIdAsync(id);
+        await deliveryService.ChangeDeliveryStatusIfNeeded(deliveryId);
 
         return Ok(DifferenceSuccessfullySetToNoDifferences);
     }

--- a/WarehouseManagement.Core/Contracts/IDifferenceService.cs
+++ b/WarehouseManagement.Core/Contracts/IDifferenceService.cs
@@ -26,4 +26,5 @@ public interface IDifferenceService
     Task FinishProcessing(int id, DifferenceAdminCommentDto adminCommentDto);
 
     Task NoDifferences(int id, DifferenceAdminCommentDto adminCommentDto);
+    Task<int> GetDeliveryIdAsync(int id);
 }

--- a/WarehouseManagement.Core/DTOs/Delivery/DeliveryDto.cs
+++ b/WarehouseManagement.Core/DTOs/Delivery/DeliveryDto.cs
@@ -12,6 +12,8 @@ public class DeliveryDto
     public string CreatedAt { get; set; } = string.Empty;
     public int EntriesWaitingProcessing { get; set; }
     public int EntriesFinishedProcessing { get; set; }
+    public int DifferencesWaitingProcessing { get; set; }
+    public int DifferencesFinishedProcessing { get; set; }
     public EntriesProcessingDetails EntriesWaitingProcessingDetails { get; set; } = null!;
     public EntriesProcessingDetails EntriesFinishedProcessingDetails { get; set; } = null!;
     public string VendorName { get; set; } = string.Empty;

--- a/WarehouseManagement.Core/Services/DeliveryService.cs
+++ b/WarehouseManagement.Core/Services/DeliveryService.cs
@@ -113,7 +113,13 @@ public class DeliveryService : IDeliveryService
                 EntriesFinishedProcessingDetails = GetEntriesProcessingDetails(d.Entries, true),
                 EntriesWaitingProcessingDetails = GetEntriesProcessingDetails(d.Entries, false),
                 EntriesFinishedProcessing = d.Entries.Count(e => e.FinishedProcessing.HasValue),
-                EntriesWaitingProcessing = d.Entries.Count(e => !e.FinishedProcessing.HasValue)
+                EntriesWaitingProcessing = d.Entries.Count(e => !e.FinishedProcessing.HasValue),
+                DifferencesFinishedProcessing = d.Differences.Count(d =>
+                    d.Status == DifferenceStatus.Finished
+                ),
+                DifferencesWaitingProcessing = d.Differences.Count(d =>
+                    d.Status == DifferenceStatus.Processing || d.Status == DifferenceStatus.Waiting
+                ),
             })
             .ToListAsync();
 
@@ -275,7 +281,7 @@ public class DeliveryService : IDeliveryService
                         MarkerId = dm.MarkerId,
                         MarkerName = dm.Marker.Name
                     })
-                    .ToList()
+                    .ToList(),
             })
             .ToListAsync();
 

--- a/WarehouseManagement.Core/Services/DifferenceService.cs
+++ b/WarehouseManagement.Core/Services/DifferenceService.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System.Linq.Expressions;
+﻿using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
 using WarehouseManagement.Common.Statuses;
 using WarehouseManagement.Common.Utilities;
 using WarehouseManagement.Core.Contracts;
@@ -60,7 +60,7 @@ public class DifferenceService : IDifferenceService
         }
 
         var difference = await repository.GetByIdAsync<Difference>(id);
-        
+
         difference!.ReceptionNumber = model.ReceptionNumber;
         difference.InternalNumber = model.InternalNumber;
         difference.ActiveNumber = model.ActiveNumber;
@@ -104,7 +104,8 @@ public class DifferenceService : IDifferenceService
                 CreatedAt = UtcNowDateTimeStringFormatted.GetUtcNow(d.CreatedAt),
                 Zone = d.Zone.Name,
                 DeliverySystemNumber = d.Delivery.SystemNumber
-            }).ToListAsync();
+            })
+            .ToListAsync();
 
         var totalItems = repository.AllReadOnly<Difference>().Count();
 
@@ -117,7 +118,9 @@ public class DifferenceService : IDifferenceService
         };
     }
 
-    public async Task<PageDto<DifferenceDto>> GetAllWithDeletedAsync(PaginationParameters paginationParams)
+    public async Task<PageDto<DifferenceDto>> GetAllWithDeletedAsync(
+        PaginationParameters paginationParams
+    )
     {
         Expression<Func<Difference, bool>> filter = v =>
             EF.Functions.Like(v.ReceptionNumber, $"%{paginationParams.SearchQuery}%")
@@ -141,7 +144,8 @@ public class DifferenceService : IDifferenceService
                 CreatedAt = UtcNowDateTimeStringFormatted.GetUtcNow(d.CreatedAt),
                 Zone = d.Zone.Name,
                 DeliverySystemNumber = d.Delivery.SystemNumber
-            }).ToListAsync();
+            })
+            .ToListAsync();
 
         var totalItems = repository.AllReadOnly<Difference>().Count();
 
@@ -260,5 +264,17 @@ public class DifferenceService : IDifferenceService
         difference.AdminComment = adminCommentDto.AdminComment;
 
         await repository.SaveChangesWithLogAsync();
+    }
+
+    public async Task<int> GetDeliveryIdAsync(int id)
+    {
+        var difference = await repository.GetByIdAsync<Difference>(id);
+
+        if (difference == null)
+        {
+            throw new KeyNotFoundException(DifferenceWithIdNotFound);
+        }
+
+        return difference.DeliveryId;
     }
 }


### PR DESCRIPTION
Currently the delivery is marked as finished when all of the entries have been processed. The delivery status should also depend on the status of its differenses.

1. Add another check in the expected status method to check for deliveries too (I am not sure about the status of the delivery here)
2. Add a method to get delivery id by difference id so we don't need to add it in the dto
3. Call the update status if needed from the difference controller. I am not sure if those are the actions that need to execute it cause I am not that familiar with the business logic

There is one thing that I am not 100%. What happens if a difference is deleted and then restored, do we change the status of the delivery?

There is also some formatting thing with my csharpier (maybe the version is different) so some files are changed more due to the formatting. Ignore that for now it will be fixed before merging.